### PR TITLE
Add Services step to onboarding wizard (#256)

### DIFF
--- a/plugins/wpappointments/assets/backend/admin/pages/OnboardingWizard/OnboardingWizard.tsx
+++ b/plugins/wpappointments/assets/backend/admin/pages/OnboardingWizard/OnboardingWizard.tsx
@@ -6,12 +6,13 @@ import Calendar from './Calendar/Calendar';
 import General from './General/General';
 import styles from './OnboardingWizard.module.css';
 import Schedule from './Schedule/Schedule';
+import ServicesStep from './Services/Services';
 import gutenbergBlock from '~/images/gutenberg-block.png';
 import logoIcon from '~/images/icons/logo-icon.svg';
 
 export function OnboardingWizard() {
 	const [currentStep, setCurrentStep] = useState(0);
-	const totalSteps = 5;
+	const totalSteps = 6;
 
 	return (
 		<div className={styles.wizard}>
@@ -46,7 +47,10 @@ export function OnboardingWizard() {
 				{currentStep === 4 && (
 					<OnboardingWizardStep4 setCurrentStep={setCurrentStep} />
 				)}
-				{currentStep === 5 && <AllSet />}
+				{currentStep === 5 && (
+					<OnboardingWizardStep5 setCurrentStep={setCurrentStep} />
+				)}
+				{currentStep === 6 && <AllSet />}
 			</div>
 		</div>
 	);
@@ -219,6 +223,29 @@ function OnboardingWizardStep4({ setCurrentStep }: StepProps) {
 				</p>
 			</div>
 			<Schedule
+				onSuccess={() => {
+					setCurrentStep((prev) => prev + 1);
+				}}
+			/>
+		</div>
+	);
+}
+
+function OnboardingWizardStep5({ setCurrentStep }: StepProps) {
+	return (
+		<div style={{ margin: '40px auto' }}>
+			<div className={styles.stepHeader}>
+				<h1 className={styles.title}>
+					{__('Set up your services', 'wpappointments')}
+				</h1>
+				<p className={styles.leadText}>
+					{__(
+						'Add the services you offer. You can add as many as you need and manage them later from the Services page.',
+						'wpappointments'
+					)}
+				</p>
+			</div>
+			<ServicesStep
 				onSuccess={() => {
 					setCurrentStep((prev) => prev + 1);
 				}}

--- a/plugins/wpappointments/assets/backend/admin/pages/OnboardingWizard/Services/Services.tsx
+++ b/plugins/wpappointments/assets/backend/admin/pages/OnboardingWizard/Services/Services.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from 'react';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Service } from '~/backend/types';
+import styles from '../OnboardingWizard.module.css';
+import { HtmlForm, withForm } from '~/backend/admin/components/Form/Form';
+import Input from '~/backend/admin/components/FormField/Input/Input';
+import FormFieldSet from '~/backend/admin/components/FormFieldSet/FormFieldSet';
+import { servicesApi, CreateServiceData } from '~/backend/api/services';
+
+type ServiceFormData = {
+	name: string;
+	duration: number;
+};
+
+type ServicesProps = {
+	onSuccess: () => void;
+};
+
+function AddServiceForm({ onAdd }: { onAdd: (service: Service) => void }) {
+	const onSubmit = async (data: ServiceFormData) => {
+		const { createService } = servicesApi();
+		const serviceData: CreateServiceData = {
+			name: data.name,
+			duration: Number(data.duration),
+			active: true,
+		};
+
+		const response = await createService(serviceData);
+
+		if (response && response.status === 'success') {
+			onAdd(response.data.service as Service);
+		}
+	};
+
+	return (
+		<HtmlForm onSubmit={onSubmit}>
+			<FormFieldSet style={{ marginBottom: 16 }}>
+				<Input
+					name="name"
+					label={__('Service name', 'wpappointments')}
+					placeholder={__('e.g. Consultation', 'wpappointments')}
+					rules={{ required: true }}
+				/>
+				<Input
+					name="duration"
+					label={__('Duration (minutes)', 'wpappointments')}
+					type="number"
+					rules={{ required: true, min: 1 }}
+				/>
+			</FormFieldSet>
+			<Button variant="secondary" type="submit">
+				{__('Add Service', 'wpappointments')}
+			</Button>
+		</HtmlForm>
+	);
+}
+
+const AddServiceFormWithForm = withForm(AddServiceForm);
+
+function ServicesStep({ onSuccess }: ServicesProps) {
+	const [services, setServices] = useState<Service[]>([]);
+	const [isLoading, setIsLoading] = useState(true);
+
+	useEffect(() => {
+		const { getServices } = servicesApi();
+
+		setIsLoading(true);
+
+		Promise.resolve(getServices()).then((result: any) => {
+			setServices(result?.services || []);
+			setIsLoading(false);
+		});
+	}, []);
+
+	const handleAdd = (service: Service) => {
+		setServices((prev) => [...prev, service]);
+	};
+
+	const handleDelete = async (id: number) => {
+		const { deleteService } = servicesApi();
+		await deleteService(id);
+		setServices((prev) => prev.filter((s) => s.id !== id));
+	};
+
+	return (
+		<div>
+			{services.length > 0 && (
+				<table
+					className="wp-list-table widefat fixed striped"
+					style={{ marginBottom: 24 }}
+				>
+					<thead>
+						<tr>
+							<th>{__('Name', 'wpappointments')}</th>
+							<th style={{ width: 120 }}>
+								{__('Duration (min)', 'wpappointments')}
+							</th>
+							<th style={{ width: 80 }}>
+								{__('Remove', 'wpappointments')}
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						{services.map((service) => (
+							<tr key={service.id}>
+								<td>{service.name}</td>
+								<td>{service.duration ?? '—'}</td>
+								<td>
+									<Button
+										variant="link"
+										isDestructive
+										onClick={() =>
+											service.id &&
+											handleDelete(service.id)
+										}
+									>
+										{__('Remove', 'wpappointments')}
+									</Button>
+								</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			)}
+
+			{!isLoading && services.length === 0 && (
+				<p style={{ color: '#757575', marginBottom: 16 }}>
+					{__(
+						'No services added yet. Add your first service below.',
+						'wpappointments'
+					)}
+				</p>
+			)}
+
+			<AddServiceFormWithForm onAdd={handleAdd} />
+
+			<Button
+				className={styles.stepButton}
+				variant="primary"
+				onClick={onSuccess}
+				style={{ marginTop: 24 }}
+			>
+				{__('Continue', 'wpappointments')}
+			</Button>
+		</div>
+	);
+}
+
+export default ServicesStep;


### PR DESCRIPTION
## Summary

- New Step 5 in the onboarding wizard: **Set up your services**
- Users can add services (name + duration) inline during wizard setup
- Added services are listed in a table with a Remove action
- "Continue" advances to All Set (step 6); step is skippable
- `totalSteps` bumped from 5 → 6

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)