### PR TITLE
feat: Add Entities admin UI

### DIFF
--- a/plugins/wpappointments/assets/backend/admin.tsx
+++ b/plugins/wpappointments/assets/backend/admin.tsx
@@ -6,6 +6,7 @@ import { OnboardingWizard } from './admin/pages/OnboardingWizard/OnboardingWizar
 import Calendar from '~/backend/admin/pages/Calendar/Calendar';
 import Customers from '~/backend/admin/pages/Customers/Customers';
 import Dashboard from '~/backend/admin/pages/Dashboard/Dashboard';
+import Entities from '~/backend/admin/pages/Entities/Entities';
 import Services from '~/backend/admin/pages/Services/Services';
 import Settings from '~/backend/admin/pages/Settings/Settings';
 
@@ -16,6 +17,7 @@ pages.set('dashboard', <Dashboard />);
 pages.set('calendar', <Calendar />);
 pages.set('customers', <Customers />);
 pages.set('services', <Services />);
+pages.set('entities', <Entities />);
 pages.set('settings', <Settings />);
 pages.set('wizard', <OnboardingWizard />);
 

--- a/plugins/wpappointments/assets/backend/admin/components/EntityCreate/EntityCreate.tsx
+++ b/plugins/wpappointments/assets/backend/admin/components/EntityCreate/EntityCreate.tsx
@@ -1,0 +1,210 @@
+import { useState } from 'react';
+import { SubmitHandler } from 'react-hook-form';
+import { Button, SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import useFillFormValues from '~/backend/hooks/useFillFormValues';
+import useSlideout from '~/backend/hooks/useSlideout';
+import { Entity } from '~/backend/types';
+import { HtmlForm, withForm } from '../Form/Form';
+import Input from '../FormField/Input/Input';
+import Toggle from '../FormField/Toggle/Toggle';
+import FormFieldSet from '../FormFieldSet/FormFieldSet';
+import SlideOut from '../SlideOut/SlideOut';
+import {
+	entitiesApi,
+	CreateEntityData,
+	UpdateEntityData,
+} from '~/backend/api/entities';
+
+export type EntityFormData = {
+	id?: number;
+	name: string;
+	description?: string;
+	type?: string;
+	capacity?: number;
+	active?: boolean;
+	scheduleMode?: 'inherit' | 'own';
+	bufferBefore?: number;
+	bufferAfter?: number;
+	sortOrder?: number;
+};
+
+type EntityCreateProps = {
+	onSubmitSuccess?: (data: Entity) => void;
+	invalidateCache?: (selector: string) => void;
+};
+
+export default withForm(function EntityCreate({
+	onSubmitSuccess,
+	invalidateCache,
+}: EntityCreateProps) {
+	const { currentSlideout, closeCurrentSlideOut } = useSlideout();
+	const { data } = currentSlideout || {};
+	const { selectedEntity, mode, parentId } = (data as any) || {};
+
+	if (mode === 'edit' && selectedEntity) {
+		useFillFormValues(selectedEntity);
+	}
+
+	const [isActive, setIsActive] = useState<boolean>(
+		selectedEntity?.active ?? true
+	);
+
+	const [scheduleMode, setScheduleMode] = useState<string>(
+		selectedEntity?.scheduleMode ?? 'inherit'
+	);
+
+	const onSubmit: SubmitHandler<EntityFormData> = async (formData) => {
+		const { createEntity, updateEntity } = entitiesApi({
+			invalidateCache,
+		});
+
+		if (mode === 'edit' && selectedEntity?.id) {
+			const updateData: UpdateEntityData = {
+				...formData,
+				id: selectedEntity.id,
+				parentId: selectedEntity.parentId,
+				capacity: formData.capacity ? Number(formData.capacity) : 1,
+				bufferBefore: formData.bufferBefore
+					? Number(formData.bufferBefore)
+					: 0,
+				bufferAfter: formData.bufferAfter
+					? Number(formData.bufferAfter)
+					: 0,
+				sortOrder: formData.sortOrder ? Number(formData.sortOrder) : 0,
+				scheduleMode: scheduleMode as 'inherit' | 'own',
+			};
+
+			const response = await updateEntity(updateData);
+
+			if (response && response.status === 'success') {
+				const { entity } = response.data;
+
+				if (onSubmitSuccess) {
+					onSubmitSuccess(entity as Entity);
+				}
+			}
+		} else {
+			const createData: CreateEntityData = {
+				name: formData.name,
+				parentId: parentId ?? 0,
+				description: formData.description,
+				type: formData.type,
+				capacity: formData.capacity ? Number(formData.capacity) : 1,
+				active: formData.active ?? true,
+				bufferBefore: formData.bufferBefore
+					? Number(formData.bufferBefore)
+					: 0,
+				bufferAfter: formData.bufferAfter
+					? Number(formData.bufferAfter)
+					: 0,
+				sortOrder: formData.sortOrder ? Number(formData.sortOrder) : 0,
+				scheduleMode: scheduleMode as 'inherit' | 'own',
+			};
+
+			const response = await createEntity(createData);
+
+			if (response && response.status === 'success') {
+				const { entity } = response.data;
+
+				if (onSubmitSuccess) {
+					onSubmitSuccess(entity as Entity);
+				}
+			}
+		}
+
+		closeCurrentSlideOut();
+	};
+
+	const submitText =
+		mode === 'edit'
+			? __('Update', 'wpappointments')
+			: __('Create', 'wpappointments');
+
+	const title =
+		mode === 'edit'
+			? __('Edit Entity', 'wpappointments')
+			: __('New Entity', 'wpappointments');
+
+	return (
+		<SlideOut title={title} id="entity">
+			<HtmlForm onSubmit={onSubmit}>
+				<FormFieldSet>
+					<Input
+						name="name"
+						label={__('Name', 'wpappointments')}
+						rules={{ required: true }}
+					/>
+					<Input
+						name="description"
+						label={__('Description', 'wpappointments')}
+					/>
+					<Input
+						name="type"
+						label={__('Type', 'wpappointments')}
+						placeholder={__(
+							'e.g. room, table, equipment',
+							'wpappointments'
+						)}
+					/>
+					<Input
+						name="capacity"
+						label={__('Capacity', 'wpappointments')}
+						type="number"
+					/>
+					<SelectControl
+						label={__('Schedule Mode', 'wpappointments')}
+						value={scheduleMode}
+						options={[
+							{
+								label: __(
+									'Inherit from parent',
+									'wpappointments'
+								),
+								value: 'inherit',
+							},
+							{
+								label: __('Own schedule', 'wpappointments'),
+								value: 'own',
+							},
+						]}
+						onChange={(value: string) => setScheduleMode(value)}
+					/>
+					<Input
+						name="bufferBefore"
+						label={__('Buffer before (minutes)', 'wpappointments')}
+						type="number"
+					/>
+					<Input
+						name="bufferAfter"
+						label={__('Buffer after (minutes)', 'wpappointments')}
+						type="number"
+					/>
+					<Input
+						name="sortOrder"
+						label={__('Sort Order', 'wpappointments')}
+						type="number"
+					/>
+					<Toggle
+						name="active"
+						label={__('Active', 'wpappointments')}
+						defaultChecked={isActive}
+						onChange={(value: boolean) => setIsActive(value)}
+					/>
+				</FormFieldSet>
+				<Button
+					variant="primary"
+					type="submit"
+					style={{
+						width: '100%',
+						justifyContent: 'center',
+						padding: '22px 0px',
+						marginTop: '34px',
+					}}
+				>
+					{submitText}
+				</Button>
+			</HtmlForm>
+		</SlideOut>
+	);
+});

--- a/plugins/wpappointments/assets/backend/admin/pages/Entities/Entities.tsx
+++ b/plugins/wpappointments/assets/backend/admin/pages/Entities/Entities.tsx
@@ -1,0 +1,278 @@
+import { useState } from 'react';
+import { Button, Card, CardHeader } from '@wordpress/components';
+import { select, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { Icon, edit, trash, update, plus } from '@wordpress/icons';
+import { Text } from '~/backend/utils/experimental';
+import useSlideout from '~/backend/hooks/useSlideout';
+import { store } from '~/backend/store/store';
+import { Entity } from '~/backend/types';
+import CardBody from '~/backend/admin/components/CardBody/CardBody';
+import { DataViews } from '~/backend/admin/components/DataViews/DataViews';
+import { Action } from '~/backend/admin/components/DataViews/types';
+import EntityCreate from '~/backend/admin/components/EntityCreate/EntityCreate';
+import DeleteModal from '~/backend/admin/components/Modals/DeleteModal/DeleteModal';
+import TableFullEmpty from '~/backend/admin/components/TableFullEmpty/TableFullEmpty';
+import { StateContextProvider } from '~/backend/admin/context/StateContext';
+import { useStateContext } from '~/backend/admin/context/StateContext';
+import LayoutDefault from '~/backend/admin/layouts/LayoutDefault/LayoutDefault';
+import { entitiesApi } from '~/backend/api/entities';
+import { COLORS as colors } from '~/backend/constants';
+import globalStyles from 'global.module.css';
+
+type Fields = {
+	paged: number;
+	number: number;
+};
+
+type View = {
+	type: 'table';
+	layout: object;
+	hiddenFields: [];
+	perPage: number;
+	page: number;
+};
+
+function EntitiesTable() {
+	const { openSlideOut } = useSlideout({ id: 'entity' });
+	const [entityModal, setEntityModal] = useState<{ id: number } | null>(null);
+	const { invalidate, getSelector } = useStateContext();
+	const { deleteEntity, updateEntity } = entitiesApi({
+		invalidateCache: invalidate,
+	});
+	const [filters, setFilters] = useState<Fields>({ paged: 1, number: 10 });
+
+	const { entities, totalItems, totalPages, currentPage } = useSelect(() => {
+		return select(store).getEntities({
+			...filters,
+			version: getSelector('getEntities'),
+		});
+	}, [filters, getSelector('getEntities')]);
+
+	const [view, setView] = useState<View>({
+		type: 'table',
+		layout: {},
+		hiddenFields: [],
+		perPage: 10,
+		page: currentPage,
+	});
+
+	const addEntity = () => {
+		openSlideOut({ id: 'entity', data: { mode: 'create' } });
+	};
+
+	const editEntity = (row: Entity) => {
+		openSlideOut({
+			id: 'entity',
+			data: { selectedEntity: row, mode: 'edit' },
+		});
+	};
+
+	const addChildEntity = (row: Entity) => {
+		openSlideOut({
+			id: 'entity',
+			data: { mode: 'create', parentId: row.id },
+		});
+	};
+
+	if (!entities || entities.length === 0) {
+		return (
+			<TableFullEmpty>
+				<p>{__('You have no entities yet', 'wpappointments')}</p>
+				<Button variant="primary" onClick={addEntity}>
+					{__('Create New Entity', 'wpappointments')}
+				</Button>
+			</TableFullEmpty>
+		);
+	}
+
+	const fields = [
+		{
+			id: 'name',
+			header: __('Name', 'wpappointments'),
+			render: ({ item }: { item: Entity }) => (
+				<strong>{item.name}</strong>
+			),
+			enableSorting: false,
+			enableHiding: false,
+		},
+		{
+			id: 'type',
+			header: __('Type', 'wpappointments'),
+			render: ({ item }: { item: Entity }) => (
+				<span>{item.type || '—'}</span>
+			),
+			enableSorting: false,
+			enableHiding: false,
+		},
+		{
+			id: 'capacity',
+			header: __('Capacity', 'wpappointments'),
+			render: ({ item }: { item: Entity }) => (
+				<span>{item.capacity ?? 1}</span>
+			),
+			enableSorting: false,
+			enableHiding: false,
+		},
+		{
+			id: 'scheduleMode',
+			header: __('Schedule', 'wpappointments'),
+			render: ({ item }: { item: Entity }) => (
+				<span>
+					{item.scheduleMode === 'own'
+						? __('Own', 'wpappointments')
+						: __('Inherited', 'wpappointments')}
+				</span>
+			),
+			enableSorting: false,
+			enableHiding: false,
+		},
+		{
+			id: 'active',
+			header: __('Status', 'wpappointments'),
+			render: ({ item }: { item: Entity }) => (
+				<span
+					style={{
+						color: item.active ? colors.green : colors.gray,
+						fontWeight: 600,
+					}}
+				>
+					{item.active
+						? __('Active', 'wpappointments')
+						: __('Inactive', 'wpappointments')}
+				</span>
+			),
+			enableSorting: false,
+			enableHiding: false,
+		},
+	];
+
+	const toggleEntityActive = async (item: Entity) => {
+		if (item.id) {
+			await updateEntity({
+				id: item.id,
+				name: item.name,
+				parentId: item.parentId,
+				active: !item.active,
+				description: item.description,
+				type: item.type,
+				capacity: item.capacity,
+				image: item.image,
+				scheduleId: item.scheduleId,
+				scheduleMode: item.scheduleMode,
+				bufferBefore: item.bufferBefore,
+				bufferAfter: item.bufferAfter,
+				minLeadTime: item.minLeadTime,
+				maxLeadTime: item.maxLeadTime,
+				sortOrder: item.sortOrder,
+			});
+		}
+	};
+
+	const actions: Action[] = [
+		{
+			id: 'add-child',
+			icon: <Icon icon={plus} color={colors.blue} />,
+			isPrimary: true,
+			label: __('Add child entity', 'wpappointments'),
+			callback: (item: Entity) => addChildEntity(item),
+		},
+		{
+			id: 'toggle-active',
+			icon: <Icon icon={update} color={colors.gray} />,
+			isPrimary: true,
+			label: __('Toggle active/inactive', 'wpappointments'),
+			callback: (item: Entity) => toggleEntityActive(item),
+		},
+		{
+			id: 'edit',
+			icon: <Icon icon={edit} color={colors.blue} />,
+			isPrimary: true,
+			label: __('Edit entity', 'wpappointments'),
+			callback: (item: Entity) => editEntity(item),
+		},
+		{
+			id: 'delete',
+			icon: <Icon icon={trash} color={colors.red} />,
+			isPrimary: true,
+			isDestructive: true,
+			label: __('Delete entity', 'wpappointments'),
+			callback: (item: Entity) => {
+				if (item.id) {
+					setEntityModal({ id: item.id });
+				}
+			},
+		},
+	];
+
+	return (
+		<>
+			<DataViews
+				view={view}
+				onChangeView={(currentState: View) => {
+					setView(currentState);
+					setFilters({
+						paged: currentState.page,
+						number: currentState.perPage,
+					});
+
+					invalidate('getEntities');
+				}}
+				fields={fields}
+				actions={actions}
+				data={entities}
+				paginationInfo={{
+					totalItems,
+					totalPages,
+				}}
+			/>
+			{entityModal && (
+				<DeleteModal
+					title={__('Delete Entity', 'wpappointments')}
+					message={__(
+						'Are you sure you want to delete this entity? Child entities will be reassigned to the parent.',
+						'wpappointments'
+					)}
+					onConfirmClick={async () => {
+						await deleteEntity(entityModal.id);
+						setEntityModal(null);
+					}}
+					closeModal={() => setEntityModal(null)}
+				/>
+			)}
+		</>
+	);
+}
+
+export default function Entities() {
+	const { openSlideOut, isSlideoutOpen } = useSlideout();
+
+	return (
+		<StateContextProvider>
+			<LayoutDefault title="Entities">
+				<Card className={globalStyles.card}>
+					<CardHeader>
+						<Text size="title">
+							{__('All Entities', 'wpappointments')}
+						</Text>
+						<Button
+							variant="primary"
+							onClick={() =>
+								openSlideOut({
+									id: 'entity',
+									data: { mode: 'create' },
+								})
+							}
+						>
+							{__('Create New Entity', 'wpappointments')}
+						</Button>
+					</CardHeader>
+					<CardBody>
+						<EntitiesTable />
+					</CardBody>
+				</Card>
+				{isSlideoutOpen('entity') && <EntityCreate />}
+			</LayoutDefault>
+		</StateContextProvider>
+	);
+}

--- a/plugins/wpappointments/assets/backend/store/actions.ts
+++ b/plugins/wpappointments/assets/backend/store/actions.ts
@@ -2,6 +2,7 @@ import { APIFetchOptions } from '@wordpress/api-fetch';
 import { actions as appointments } from './appointments/appointments';
 import { actions as availability } from './availability/availability';
 import { actions as customers } from './customers/customers';
+import { actions as entities } from './entities/entities';
 import { actions as notices } from './notices/notices';
 import { actions as services } from './services/services';
 import { actions as settings } from './settings/settings';
@@ -31,5 +32,6 @@ export default {
 	...availability,
 	...appointmentSlideoutActions,
 	...customers,
+	...entities,
 	...services,
 };

--- a/plugins/wpappointments/assets/backend/store/controls.ts
+++ b/plugins/wpappointments/assets/backend/store/controls.ts
@@ -3,6 +3,7 @@ import apiFetch from '~/backend/utils/fetch';
 import { controls as appointments } from './appointments/appointments';
 import { controls as availability } from './availability/availability';
 import { controls as customers } from './customers/customers';
+import { controls as entities } from './entities/entities';
 import { controls as notices } from './notices/notices';
 import { controls as services } from './services/services';
 import { controls as settings } from './settings/settings';
@@ -32,5 +33,6 @@ export default {
 	...notices,
 	...availability,
 	...customers,
+	...entities,
 	...services,
 };

--- a/plugins/wpappointments/assets/backend/store/entities/entities.ts
+++ b/plugins/wpappointments/assets/backend/store/entities/entities.ts
@@ -1,0 +1,120 @@
+import { addQueryArgs } from '@wordpress/url';
+import { produce } from 'immer';
+import apiFetch, { APIResponse } from '~/backend/utils/fetch';
+import { Entity } from '~/backend/types';
+import { FetchFromApiActionReturn, baseActions } from '../actions';
+import { type State } from '../store';
+import { type EntitiesState } from './entities.types';
+
+type Action = ReturnType<(typeof actions)[keyof typeof actions]>;
+type Query = Record<string, any>;
+type Response = APIResponse<EntitiesState>;
+
+export const DEFAULT_ENTITIES_STATE: EntitiesState = {
+	entities: [],
+	totalItems: 0,
+	totalPages: 1,
+	postsPerPage: 10,
+	currentPage: 1,
+};
+
+export const actions = {
+	setEntities({
+		entities,
+		totalItems,
+		totalPages,
+		postsPerPage,
+		currentPage,
+	}: EntitiesState) {
+		return {
+			type: 'SET_ENTITIES',
+			entities,
+			totalItems,
+			totalPages,
+			postsPerPage,
+			currentPage,
+		} as const;
+	},
+	createEntity(entity: Entity) {
+		return {
+			type: 'CREATE_ENTITY',
+			entity,
+		} as const;
+	},
+	updateEntity(entity: Entity) {
+		return {
+			type: 'UPDATE_ENTITY',
+			entity,
+		} as const;
+	},
+	deleteEntity(id: number) {
+		return {
+			type: 'DELETE_ENTITY',
+			id,
+		} as const;
+	},
+};
+
+export const reducer = (state = DEFAULT_ENTITIES_STATE, action: Action) => {
+	switch (action.type) {
+		case 'SET_ENTITIES':
+			return produce(state, () => {
+				return action;
+			});
+
+		case 'CREATE_ENTITY':
+			return produce(state, (draft) => {
+				draft.entities.unshift(action.entity);
+			});
+
+		case 'UPDATE_ENTITY':
+			return produce(state, (draft) => {
+				draft.entities = draft.entities.map((entity: Entity) =>
+					entity.id === action.entity.id ? action.entity : entity
+				);
+			});
+
+		case 'DELETE_ENTITY':
+			return produce(state, (draft) => {
+				draft.entities = draft.entities.filter(
+					(entity: Entity) => entity.id !== action.id
+				);
+			});
+
+		default:
+			return state;
+	}
+};
+
+export const selectors = {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	getEntities(state: State, _?: Query) {
+		return state.entities;
+	},
+};
+
+export const controls = {
+	SET_ENTITIES() {
+		return apiFetch({ path: 'entities' });
+	},
+};
+
+export const resolvers = {
+	*getEntities(query: Query): Generator<
+		FetchFromApiActionReturn,
+		{
+			type: string;
+			entities: Entity[];
+		},
+		Response
+	> {
+		const response = yield baseActions.fetchFromAPI(
+			addQueryArgs('entities', {
+				query,
+			})
+		);
+		const { data } = response;
+
+		return actions.setEntities(data);
+	},
+};

--- a/plugins/wpappointments/assets/backend/store/entities/entities.types.ts
+++ b/plugins/wpappointments/assets/backend/store/entities/entities.types.ts
@@ -1,0 +1,9 @@
+import { Entity } from '~/backend/types';
+
+export type EntitiesState = {
+	entities: Entity[];
+	totalItems: number;
+	totalPages: number;
+	postsPerPage: number;
+	currentPage: number;
+};

--- a/plugins/wpappointments/assets/backend/store/reducers.ts
+++ b/plugins/wpappointments/assets/backend/store/reducers.ts
@@ -1,6 +1,7 @@
 import { reducer as appointments } from './appointments/appointments';
 import { reducer as availability } from './availability/availability';
 import { reducer as customers } from './customers/customers';
+import { reducer as entities } from './entities/entities';
 import { reducer as notices } from './notices/notices';
 import { reducer as services } from './services/services';
 import { reducer as settings } from './settings/settings';
@@ -15,5 +16,6 @@ export default {
 	availability,
 	appointmentSlideout,
 	customers,
+	entities,
 	services,
 };

--- a/plugins/wpappointments/assets/backend/store/resolvers.ts
+++ b/plugins/wpappointments/assets/backend/store/resolvers.ts
@@ -1,6 +1,7 @@
 import { resolvers as appointments } from './appointments/appointments';
 import { resolvers as availability } from './availability/availability';
 import { resolvers as customers } from './customers/customers';
+import { resolvers as entities } from './entities/entities';
 import { resolvers as notices } from './notices/notices';
 import { resolvers as services } from './services/services';
 import { resolvers as settings } from './settings/settings';
@@ -13,5 +14,6 @@ export default {
 	...notices,
 	...availability,
 	...customers,
+	...entities,
 	...services,
 };

--- a/plugins/wpappointments/assets/backend/store/selectors.ts
+++ b/plugins/wpappointments/assets/backend/store/selectors.ts
@@ -1,6 +1,7 @@
 import { selectors as appointments } from './appointments/appointments';
 import { selectors as availability } from './availability/availability';
 import { selectors as customers } from './customers/customers';
+import { selectors as entities } from './entities/entities';
 import { selectors as notices } from './notices/notices';
 import { selectors as services } from './services/services';
 import { selectors as settings } from './settings/settings';
@@ -15,5 +16,6 @@ export default {
 	...availability,
 	...appointmentSlideoutSelectors,
 	...customers,
+	...entities,
 	...services,
 };

--- a/plugins/wpappointments/assets/backend/store/store.ts
+++ b/plugins/wpappointments/assets/backend/store/store.ts
@@ -4,6 +4,7 @@ import { AppointmentsState } from './appointments/appointments.types';
 import { AvailabilityState } from './availability/availability.types';
 import controls from './controls';
 import { CustomersState } from './customers/customers.types';
+import { EntitiesState } from './entities/entities.types';
 import { NoticesState } from './notices/notices.types';
 import reducers from './reducers';
 import resolvers from './resolvers';
@@ -21,6 +22,7 @@ export type State = {
 	availability: AvailabilityState;
 	appointmentSlideout: AppointmentSlideoutState;
 	customers: CustomersState;
+	entities: EntitiesState;
 	services: ServicesState;
 };
 

--- a/plugins/wpappointments/includes/admin/menu.php
+++ b/plugins/wpappointments/includes/admin/menu.php
@@ -59,6 +59,15 @@ function menu() {
 
 	add_submenu_page(
 		'wpappointments',
+		__( 'Entities', 'wpappointments' ),
+		__( 'Entities', 'wpappointments' ),
+		'activate_plugins',
+		'wpappointments-entities',
+		__NAMESPACE__ . '\\entities_page'
+	);
+
+	add_submenu_page(
+		'wpappointments',
 		__( 'Settings', 'wpappointments' ),
 		__( 'Settings', 'wpappointments' ),
 		'activate_plugins',
@@ -110,6 +119,15 @@ function customers_page() {
  */
 function services_page() {
 	echo '<div id="wpappointments-admin" data-page="services"></div>';
+}
+
+/**
+ * Create entities admin page
+ *
+ * @return void
+ */
+function entities_page() {
+	echo '<div id="wpappointments-admin" data-page="entities"></div>';
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds the full frontend admin interface for managing Bookable Entities (Discussion #89)
- Implements Redux store slice (`entities/entities.ts`) with actions, reducer, selectors, resolvers, and controls
- Creates `EntitiesTable` component with paginated DataViews table (Name, Type, Capacity, Schedule, Status columns)
- Creates `EntityCreate` slideout form (name, description, type, capacity, schedule mode, buffers, sort order, active toggle)
- Registers the Entities admin menu page in PHP and the page route in `admin.tsx`
- Table actions: toggle active/inactive, edit, delete (with reassign children), add child entity

## Test plan
- [ ] Navigate to WP Appointments → Entities in the admin menu
- [ ] Verify empty state message displays when no entities exist
- [ ] Create a new entity via the "Create New Entity" button
- [ ] Edit an existing entity and verify fields populate correctly
- [ ] Toggle entity active/inactive and confirm status updates
- [ ] Delete an entity and verify child reassignment prompt
- [ ] Add a child entity using the "Add child entity" action
- [ ] Verify pagination works correctly with 10+ entities

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Entities management page to the WPAppointments admin dashboard
  * Create, edit, and delete entities with an intuitive interface
  * Manage entity properties including name, type, capacity, and scheduling mode
  * Toggle entity status directly from the management table
  * Support for hierarchical entity relationships and bulk management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->