### PR TITLE
feat: REST API endpoints for bookables, variants, availability (#354)

### DIFF
--- a/plugins/wpappointments/src/Api/Api.php
+++ b/plugins/wpappointments/src/Api/Api.php
@@ -26,5 +26,9 @@ class Api extends Core\Singleton {
 		Endpoints\SettingsController::init();
 		Endpoints\ServicesController::init();
 		Endpoints\EntitiesController::init();
+		Endpoints\BookablesController::init();
+		Endpoints\VariantsController::init();
+		Endpoints\BookableAvailabilityController::init();
+		Endpoints\BookableTypesController::init();
 	}
 }

--- a/plugins/wpappointments/src/Api/Endpoints/BookableAvailabilityController.php
+++ b/plugins/wpappointments/src/Api/Endpoints/BookableAvailabilityController.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Bookable availability controller (/availability endpoint)
+ *
+ * @package WPAppointments
+ * @since 0.4.0
+ */
+
+namespace WPAppointments\Api\Endpoints;
+
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_Error;
+use WPAppointments\Api\Controller;
+use WPAppointments\Core\Capabilities;
+use WPAppointments\Availability\AvailabilityEngine;
+use WPAppointments\Data\Model\BookableVariant;
+use WPAppointments\Data\Query\BookableVariantQuery;
+
+/**
+ * Bookable availability endpoint class
+ */
+class BookableAvailabilityController extends Controller {
+	/**
+	 * Register all routes
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		register_rest_route(
+			static::API_NAMESPACE,
+			'/bookable-availability/(?P<variant_id>\d+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( __CLASS__, 'get_variant_availability' ),
+					'permission_callback' => '__return_true',
+				),
+			)
+		);
+
+		register_rest_route(
+			static::API_NAMESPACE,
+			'/bookables/(?P<entity_id>\d+)/availability',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( __CLASS__, 'get_entity_availability' ),
+					'permission_callback' => '__return_true',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get effective availability for a variant
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function get_variant_availability( WP_REST_Request $request ) {
+		$variant_id = (int) $request->get_param( 'variant_id' );
+		$start_date = $request->get_param( 'start_date' );
+		$end_date   = $request->get_param( 'end_date' );
+
+		$variant = new BookableVariant( $variant_id );
+
+		if ( is_wp_error( $variant->variant ) ) {
+			return self::error( $variant->variant );
+		}
+
+		$date_range = array();
+
+		if ( $start_date ) {
+			$date_range['start'] = sanitize_text_field( $start_date );
+		}
+
+		if ( $end_date ) {
+			$date_range['end'] = sanitize_text_field( $end_date );
+		}
+
+		$availability = AvailabilityEngine::get_effective_availability( $variant_id, $date_range );
+
+		return self::response(
+			__( 'Availability fetched successfully', 'wpappointments' ),
+			array(
+				'variantId'    => $variant_id,
+				'availability' => $availability,
+			)
+		);
+	}
+
+	/**
+	 * Get availability for all variants of a bookable entity
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function get_entity_availability( WP_REST_Request $request ) {
+		$entity_id  = (int) $request->get_param( 'entity_id' );
+		$start_date = $request->get_param( 'start_date' );
+		$end_date   = $request->get_param( 'end_date' );
+
+		$date_range = array();
+
+		if ( $start_date ) {
+			$date_range['start'] = sanitize_text_field( $start_date );
+		}
+
+		if ( $end_date ) {
+			$date_range['end'] = sanitize_text_field( $end_date );
+		}
+
+		$results  = BookableVariantQuery::active( $entity_id );
+		$variants = array();
+
+		foreach ( $results['variants'] as $variant_post ) {
+			$variant      = new BookableVariant( $variant_post );
+			$availability = AvailabilityEngine::get_effective_availability( $variant_post->ID, $date_range );
+
+			$variants[] = array(
+				'variant'      => $variant->normalize(),
+				'availability' => $availability,
+			);
+		}
+
+		return self::response(
+			__( 'Entity availability fetched successfully', 'wpappointments' ),
+			array(
+				'entityId' => $entity_id,
+				'variants' => $variants,
+			)
+		);
+	}
+}

--- a/plugins/wpappointments/src/Api/Endpoints/BookableTypesController.php
+++ b/plugins/wpappointments/src/Api/Endpoints/BookableTypesController.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Bookable types controller (/bookable-types endpoint)
+ *
+ * @package WPAppointments
+ * @since 0.4.0
+ */
+
+namespace WPAppointments\Api\Endpoints;
+
+use WP_REST_Server;
+use WP_REST_Request;
+use WPAppointments\Api\Controller;
+use WPAppointments\Core\Capabilities;
+use WPAppointments\Bookable\BookableTypeRegistry;
+use WPAppointments\Data\Model\BookableVariant;
+
+/**
+ * Bookable types endpoint class
+ */
+class BookableTypesController extends Controller {
+	/**
+	 * Register all routes
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		register_rest_route(
+			static::API_NAMESPACE,
+			'/bookable-types',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( __CLASS__, 'get_all_types' ),
+					'permission_callback' => function () {
+						return current_user_can( Capabilities::MANAGE_BOOKABLES );
+					},
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get all registered bookable types with their field schemas
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function get_all_types( WP_REST_Request $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		$registry = BookableTypeRegistry::get_instance();
+		$types    = array();
+
+		foreach ( $registry->get_all() as $slug => $handler ) {
+			$types[] = array(
+				'slug'                     => $slug,
+				'label'                    => $handler->get_label(),
+				'fields'                   => $handler->get_fields(),
+				'variantOverridableFields' => array_merge(
+					BookableVariant::OVERRIDABLE_CORE_FIELDS,
+					$handler->get_variant_overridable_fields()
+				),
+			);
+		}
+
+		return self::response(
+			__( 'Bookable types fetched successfully', 'wpappointments' ),
+			array(
+				'types' => $types,
+			)
+		);
+	}
+}

--- a/plugins/wpappointments/src/Api/Endpoints/BookablesController.php
+++ b/plugins/wpappointments/src/Api/Endpoints/BookablesController.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Bookable entities controller (/bookables endpoint)
+ *
+ * @package WPAppointments
+ * @since 0.4.0
+ */
+
+namespace WPAppointments\Api\Endpoints;
+
+use WP_REST_Server;
+use WP_REST_Request;
+use WPAppointments\Api\Controller;
+use WPAppointments\Core\Capabilities;
+use WPAppointments\Data\Model\BookableEntity;
+use WPAppointments\Data\Model\BookableVariant;
+use WPAppointments\Data\Query\BookableQuery;
+
+/**
+ * Bookable entities endpoint class
+ */
+class BookablesController extends Controller {
+	/**
+	 * Register all routes
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		register_rest_route(
+			static::API_NAMESPACE,
+			'/bookables',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( __CLASS__, 'get_all_bookables' ),
+					'permission_callback' => function () {
+						return current_user_can( Capabilities::MANAGE_BOOKABLES );
+					},
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( __CLASS__, 'create_bookable' ),
+					'permission_callback' => function () {
+						return current_user_can( Capabilities::MANAGE_BOOKABLES );
+					},
+				),
+			)
+		);
+
+		register_rest_route(
+			static::API_NAMESPACE,
+			'/bookables/(?P<id>\d+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( __CLASS__, 'get_bookable' ),
+					'permission_callback' => function () {
+						return current_user_can( Capabilities::MANAGE_BOOKABLES );
+					},
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( __CLASS__, 'update_bookable' ),
+					'permission_callback' => function () {
+						return current_user_can( Capabilities::MANAGE_BOOKABLES );
+					},
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( __CLASS__, 'delete_bookable' ),
+					'permission_callback' => function () {
+						return current_user_can( Capabilities::MANAGE_BOOKABLES );
+					},
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get all bookable entities
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function get_all_bookables( WP_REST_Request $request ) {
+		$query = array();
+
+		$type = $request->get_param( 'type' );
+		if ( $type ) {
+			$query['type'] = sanitize_text_field( $type );
+		}
+
+		$active = $request->get_param( 'active' );
+		if ( null !== $active ) {
+			$query['active'] = filter_var( $active, FILTER_VALIDATE_BOOLEAN );
+		}
+
+		$paged = $request->get_param( 'paged' );
+		if ( $paged ) {
+			$query['paged'] = (int) $paged;
+		}
+
+		$per_page = $request->get_param( 'per_page' );
+		if ( $per_page ) {
+			$query['postsPerPage'] = (int) $per_page;
+		}
+
+		$results = BookableQuery::all( $query );
+
+		return self::response(
+			__( 'Bookable entities fetched successfully', 'wpappointments' ),
+			array(
+				'bookables'    => array_map(
+					function ( $post ) {
+						$bookable = new BookableEntity( $post );
+						return $bookable->normalize();
+					},
+					$results['bookables']
+				),
+				'totalItems'   => $results['total_items'],
+				'totalPages'   => $results['total_pages'],
+				'postsPerPage' => $results['posts_per_page'],
+				'currentPage'  => $results['current_page'],
+			)
+		);
+	}
+
+	/**
+	 * Get single bookable entity
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function get_bookable( WP_REST_Request $request ) {
+		$id       = (int) $request->get_param( 'id' );
+		$bookable = new BookableEntity( $id );
+
+		if ( is_wp_error( $bookable->bookable ) ) {
+			return self::error( $bookable->bookable );
+		}
+
+		return self::response(
+			__( 'Bookable entity fetched successfully', 'wpappointments' ),
+			array(
+				'bookable' => $bookable->normalize(),
+			)
+		);
+	}
+
+	/**
+	 * Create bookable entity
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function create_bookable( WP_REST_Request $request ) {
+		$data     = $request->get_json_params();
+		$bookable = new BookableEntity( $data );
+		$result   = $bookable->save();
+
+		if ( is_wp_error( $result ) ) {
+			return self::error( $result );
+		}
+
+		// Ensure at least one default variant exists.
+		BookableVariant::ensure_default_variant( $result->bookable->ID );
+
+		return self::response(
+			__( 'Bookable entity created successfully', 'wpappointments' ),
+			array(
+				'bookable' => $result->normalize(),
+			)
+		);
+	}
+
+	/**
+	 * Update bookable entity
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function update_bookable( WP_REST_Request $request ) {
+		$id   = (int) $request->get_param( 'id' );
+		$data = $request->get_json_params();
+
+		$bookable = new BookableEntity( $id );
+		$result   = $bookable->update( $data );
+
+		if ( is_wp_error( $result ) ) {
+			return self::error( $result );
+		}
+
+		// Sync default variant if simple bookable.
+		$sync_fields = array_intersect_key( $data, array_flip( BookableVariant::OVERRIDABLE_CORE_FIELDS ) );
+		if ( ! empty( $sync_fields ) ) {
+			BookableVariant::sync_default_variant( $id, $sync_fields );
+		}
+
+		return self::response(
+			__( 'Bookable entity updated successfully', 'wpappointments' ),
+			array(
+				'bookable' => $result->normalize(),
+			)
+		);
+	}
+
+	/**
+	 * Delete bookable entity
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function delete_bookable( WP_REST_Request $request ) {
+		$id = (int) $request->get_param( 'id' );
+
+		$bookable = new BookableEntity( $id );
+		$result   = $bookable->delete();
+
+		if ( is_wp_error( $result ) ) {
+			return self::error( $result );
+		}
+
+		return self::response(
+			__( 'Bookable entity deleted successfully', 'wpappointments' ),
+			array(
+				'bookableId' => $result,
+			)
+		);
+	}
+}

--- a/plugins/wpappointments/src/Api/Endpoints/VariantsController.php
+++ b/plugins/wpappointments/src/Api/Endpoints/VariantsController.php
@@ -1,0 +1,259 @@
+<?php
+/**
+ * Bookable variants controller (/bookables/{id}/variants endpoint)
+ *
+ * @package WPAppointments
+ * @since 0.4.0
+ */
+
+namespace WPAppointments\Api\Endpoints;
+
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_Error;
+use WPAppointments\Api\Controller;
+use WPAppointments\Core\Capabilities;
+use WPAppointments\Data\Model\BookableVariant;
+use WPAppointments\Data\Query\BookableVariantQuery;
+
+/**
+ * Variants endpoint class
+ */
+class VariantsController extends Controller {
+	/**
+	 * Register all routes
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		register_rest_route(
+			static::API_NAMESPACE,
+			'/bookables/(?P<entity_id>\d+)/variants',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( __CLASS__, 'get_variants' ),
+					'permission_callback' => function () {
+						return current_user_can( Capabilities::MANAGE_BOOKABLES );
+					},
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( __CLASS__, 'create_variant' ),
+					'permission_callback' => function () {
+						return current_user_can( Capabilities::MANAGE_BOOKABLES );
+					},
+				),
+			)
+		);
+
+		register_rest_route(
+			static::API_NAMESPACE,
+			'/bookables/(?P<entity_id>\d+)/variants/generate',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( __CLASS__, 'generate_variants' ),
+					'permission_callback' => function () {
+						return current_user_can( Capabilities::MANAGE_BOOKABLES );
+					},
+				),
+			)
+		);
+
+		register_rest_route(
+			static::API_NAMESPACE,
+			'/bookables/(?P<entity_id>\d+)/variants/(?P<variant_id>\d+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( __CLASS__, 'get_variant' ),
+					'permission_callback' => function () {
+						return current_user_can( Capabilities::MANAGE_BOOKABLES );
+					},
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( __CLASS__, 'update_variant' ),
+					'permission_callback' => function () {
+						return current_user_can( Capabilities::MANAGE_BOOKABLES );
+					},
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( __CLASS__, 'delete_variant' ),
+					'permission_callback' => function () {
+						return current_user_can( Capabilities::MANAGE_BOOKABLES );
+					},
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get all variants for a bookable entity
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function get_variants( WP_REST_Request $request ) {
+		$entity_id = (int) $request->get_param( 'entity_id' );
+		$query     = array();
+
+		$active = $request->get_param( 'active' );
+		if ( null !== $active ) {
+			$query['active'] = filter_var( $active, FILTER_VALIDATE_BOOLEAN );
+		}
+
+		$results = BookableVariantQuery::by_entity( $entity_id, $query );
+
+		return self::response(
+			__( 'Variants fetched successfully', 'wpappointments' ),
+			array(
+				'variants'     => array_map(
+					function ( $post ) {
+						$variant = new BookableVariant( $post );
+						return $variant->normalize();
+					},
+					$results['variants']
+				),
+				'totalItems'   => $results['total_items'],
+				'totalPages'   => $results['total_pages'],
+				'postsPerPage' => $results['posts_per_page'],
+				'currentPage'  => $results['current_page'],
+			)
+		);
+	}
+
+	/**
+	 * Get single variant
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function get_variant( WP_REST_Request $request ) {
+		$variant_id = (int) $request->get_param( 'variant_id' );
+		$variant    = new BookableVariant( $variant_id );
+
+		if ( is_wp_error( $variant->variant ) ) {
+			return self::error( $variant->variant );
+		}
+
+		return self::response(
+			__( 'Variant fetched successfully', 'wpappointments' ),
+			array(
+				'variant' => $variant->normalize(),
+			)
+		);
+	}
+
+	/**
+	 * Create variant
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function create_variant( WP_REST_Request $request ) {
+		$entity_id = (int) $request->get_param( 'entity_id' );
+		$data      = $request->get_json_params();
+
+		$data['parent_id'] = $entity_id;
+
+		$variant = new BookableVariant( $data );
+		$result  = $variant->save();
+
+		if ( is_wp_error( $result ) ) {
+			return self::error( $result );
+		}
+
+		return self::response(
+			__( 'Variant created successfully', 'wpappointments' ),
+			array(
+				'variant' => $result->normalize(),
+			)
+		);
+	}
+
+	/**
+	 * Update variant
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function update_variant( WP_REST_Request $request ) {
+		$variant_id = (int) $request->get_param( 'variant_id' );
+		$data       = $request->get_json_params();
+
+		$variant = new BookableVariant( $variant_id );
+		$result  = $variant->update( $data );
+
+		if ( is_wp_error( $result ) ) {
+			return self::error( $result );
+		}
+
+		return self::response(
+			__( 'Variant updated successfully', 'wpappointments' ),
+			array(
+				'variant' => $result->normalize(),
+			)
+		);
+	}
+
+	/**
+	 * Delete variant
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function delete_variant( WP_REST_Request $request ) {
+		$variant_id = (int) $request->get_param( 'variant_id' );
+
+		$variant = new BookableVariant( $variant_id );
+		$result  = $variant->delete();
+
+		if ( is_wp_error( $result ) ) {
+			return self::error( $result );
+		}
+
+		return self::response(
+			__( 'Variant deleted successfully', 'wpappointments' ),
+			array(
+				'variantId' => $result,
+			)
+		);
+	}
+
+	/**
+	 * Generate variants from attribute matrix
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function generate_variants( WP_REST_Request $request ) {
+		$entity_id = (int) $request->get_param( 'entity_id' );
+
+		$result = BookableVariant::generate_from_matrix( $entity_id );
+
+		if ( is_wp_error( $result ) ) {
+			return self::error( $result );
+		}
+
+		return self::response(
+			__( 'Variants generated successfully', 'wpappointments' ),
+			array(
+				'variants' => array_map(
+					function ( $variant ) {
+						return $variant->normalize();
+					},
+					$result
+				),
+			)
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- **BookablesController** (`/bookables`): Full CRUD with type/active filtering, pagination, auto-creates default variant on create, syncs default variant on update
- **VariantsController** (`/bookables/{id}/variants`): CRUD for variants + `/generate` endpoint for attribute matrix generation
- **BookableAvailabilityController** (`/bookable-availability/{variant_id}`, `/bookables/{id}/availability`): Public availability queries via AvailabilityEngine
- **BookableTypesController** (`/bookable-types`): Lists registered types with field schemas and variant-overridable fields

## Test plan
- [ ] Create a bookable entity via POST `/bookables` and verify default variant is auto-created
- [ ] List bookables with type and active filters
- [ ] Update a bookable and verify default variant sync
- [ ] Delete a bookable and verify cascade variant deletion
- [ ] Create/update/delete variants via `/bookables/{id}/variants`
- [ ] Generate variants from attribute matrix via `/bookables/{id}/variants/generate`
- [ ] Query availability for a variant and entity
- [ ] List registered bookable types via `/bookable-types`
- [ ] Verify all endpoints require `wpa_manage_bookables` capability (except availability which is public)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: WPPoland <hello@wppoland.com>