### PR TITLE
feat: Frontend types, API client, and Redux store for bookables (#355)

### DIFF
--- a/plugins/wpappointments/assets/backend/api/bookables.ts
+++ b/plugins/wpappointments/assets/backend/api/bookables.ts
@@ -1,0 +1,382 @@
+import { __ } from '@wordpress/i18n';
+import { missingId } from '~/backend/utils/api';
+import { Error, getErrorMessage } from '~/backend/utils/error';
+import apiFetch, { APIResponse } from '~/backend/utils/fetch';
+import resolve from '~/backend/utils/resolve';
+import { displayErrorToast, displaySuccessToast } from '~/backend/utils/toast';
+import { BookableEntity, BookableVariant, BookableType } from '~/backend/types';
+
+export type CreateBookableData = Pick<
+	BookableEntity,
+	'name' | 'type' | 'description' | 'active' | 'duration' | 'image'
+> & {
+	bufferBefore?: number;
+	bufferAfter?: number;
+	minLeadTime?: number;
+	maxLeadTime?: number;
+	attributes?: Array<{ name: string; values: string[] }>;
+};
+
+export type UpdateBookableData = Pick<BookableEntity, 'id'> &
+	Partial<CreateBookableData>;
+
+type GetAllResponse = APIResponse<{
+	bookables: BookableEntity[];
+	totalItems: number;
+	totalPages: number;
+	postsPerPage: number;
+	currentPage: number;
+}>;
+
+type MutateResponse = APIResponse<{
+	bookable: BookableEntity;
+}>;
+
+type DeleteResponse = APIResponse<{
+	bookableId: number;
+}>;
+
+type VariantsResponse = APIResponse<{
+	variants: BookableVariant[];
+	totalItems: number;
+	totalPages: number;
+	postsPerPage: number;
+	currentPage: number;
+}>;
+
+type VariantMutateResponse = APIResponse<{
+	variant: BookableVariant;
+}>;
+
+type VariantDeleteResponse = APIResponse<{
+	variantId: number;
+}>;
+
+type GenerateVariantsResponse = APIResponse<{
+	variants: BookableVariant[];
+}>;
+
+type TypesResponse = APIResponse<{
+	types: BookableType[];
+}>;
+
+type AvailabilityResponse = APIResponse<{
+	variantId: number;
+	availability: Record<string, unknown>;
+}>;
+
+export type BookablesApiOptions = {
+	invalidateCache?: (selector: string) => void;
+};
+
+export function bookablesApi(options?: BookablesApiOptions) {
+	const apiPath = 'bookables';
+	const { invalidateCache } = options || {};
+
+	async function getBookables(params?: {
+		type?: string;
+		active?: boolean;
+		paged?: number;
+		per_page?: number;
+	}) {
+		const query = new URLSearchParams();
+		if (params?.type) query.set('type', params.type);
+		if (params?.active !== undefined)
+			query.set('active', String(params.active));
+		if (params?.paged) query.set('paged', String(params.paged));
+		if (params?.per_page) query.set('per_page', String(params.per_page));
+
+		const path = query.toString()
+			? `${apiPath}?${query.toString()}`
+			: apiPath;
+
+		const [error, response] = await resolve<GetAllResponse>(async () => {
+			return await apiFetch<GetAllResponse>({ path });
+		});
+
+		if (error) {
+			handleError(
+				error,
+				__('Error fetching bookable entities', 'wpappointments')
+			);
+			return null;
+		}
+
+		return response;
+	}
+
+	async function createBookable(data: CreateBookableData) {
+		const [error, response] = await resolve<MutateResponse>(async () => {
+			return await apiFetch<MutateResponse>({
+				path: apiPath,
+				method: 'POST',
+				data,
+			});
+		});
+
+		if (error) {
+			handleError(
+				error,
+				__('Error creating bookable entity', 'wpappointments')
+			);
+		}
+
+		if (response && response.status === 'success') {
+			displaySuccessToast(
+				__('Bookable entity created successfully', 'wpappointments')
+			);
+			if (invalidateCache) {
+				invalidateCache('getBookables');
+			}
+		}
+
+		return response;
+	}
+
+	async function updateBookable(data: UpdateBookableData) {
+		const [error, response] = await resolve<MutateResponse>(async () => {
+			return await apiFetch<MutateResponse>({
+				path: `${apiPath}/${data.id}`,
+				method: 'POST',
+				data,
+			});
+		});
+
+		if (error) {
+			handleError(
+				error,
+				__('Error updating bookable entity', 'wpappointments')
+			);
+		}
+
+		if (response && response.status === 'success') {
+			displaySuccessToast(
+				__('Bookable entity updated successfully', 'wpappointments')
+			);
+			if (invalidateCache) {
+				invalidateCache('getBookables');
+			}
+		}
+
+		return response;
+	}
+
+	async function deleteBookable(id: number) {
+		if (missingId(id, 'Cannot delete bookable entity')) {
+			return;
+		}
+
+		const [error, response] = await resolve<DeleteResponse>(async () => {
+			return await apiFetch<DeleteResponse>({
+				path: `${apiPath}/${id}`,
+				method: 'DELETE',
+			});
+		});
+
+		if (error) {
+			handleError(
+				error,
+				__('Cannot delete bookable entity', 'wpappointments')
+			);
+			return;
+		}
+
+		if (response && response.status === 'success') {
+			displaySuccessToast(
+				__('Bookable entity deleted successfully', 'wpappointments')
+			);
+			if (invalidateCache) {
+				invalidateCache('getBookables');
+			}
+		}
+
+		return response;
+	}
+
+	async function getVariants(entityId: number) {
+		const [error, response] = await resolve<VariantsResponse>(async () => {
+			return await apiFetch<VariantsResponse>({
+				path: `${apiPath}/${entityId}/variants`,
+			});
+		});
+
+		if (error) {
+			handleError(error, __('Error fetching variants', 'wpappointments'));
+			return null;
+		}
+
+		return response;
+	}
+
+	async function createVariant(
+		entityId: number,
+		data: Partial<BookableVariant>
+	) {
+		const [error, response] = await resolve<VariantMutateResponse>(
+			async () => {
+				return await apiFetch<VariantMutateResponse>({
+					path: `${apiPath}/${entityId}/variants`,
+					method: 'POST',
+					data,
+				});
+			}
+		);
+
+		if (error) {
+			handleError(error, __('Error creating variant', 'wpappointments'));
+		}
+
+		if (response && response.status === 'success') {
+			displaySuccessToast(
+				__('Variant created successfully', 'wpappointments')
+			);
+		}
+
+		return response;
+	}
+
+	async function updateVariant(
+		entityId: number,
+		variantId: number,
+		data: Partial<BookableVariant>
+	) {
+		const [error, response] = await resolve<VariantMutateResponse>(
+			async () => {
+				return await apiFetch<VariantMutateResponse>({
+					path: `${apiPath}/${entityId}/variants/${variantId}`,
+					method: 'POST',
+					data,
+				});
+			}
+		);
+
+		if (error) {
+			handleError(error, __('Error updating variant', 'wpappointments'));
+		}
+
+		if (response && response.status === 'success') {
+			displaySuccessToast(
+				__('Variant updated successfully', 'wpappointments')
+			);
+		}
+
+		return response;
+	}
+
+	async function deleteVariant(entityId: number, variantId: number) {
+		const [error, response] = await resolve<VariantDeleteResponse>(
+			async () => {
+				return await apiFetch<VariantDeleteResponse>({
+					path: `${apiPath}/${entityId}/variants/${variantId}`,
+					method: 'DELETE',
+				});
+			}
+		);
+
+		if (error) {
+			handleError(error, __('Cannot delete variant', 'wpappointments'));
+			return;
+		}
+
+		if (response && response.status === 'success') {
+			displaySuccessToast(
+				__('Variant deleted successfully', 'wpappointments')
+			);
+		}
+
+		return response;
+	}
+
+	async function generateVariants(entityId: number) {
+		const [error, response] = await resolve<GenerateVariantsResponse>(
+			async () => {
+				return await apiFetch<GenerateVariantsResponse>({
+					path: `${apiPath}/${entityId}/variants/generate`,
+					method: 'POST',
+				});
+			}
+		);
+
+		if (error) {
+			handleError(
+				error,
+				__('Error generating variants', 'wpappointments')
+			);
+		}
+
+		if (response && response.status === 'success') {
+			displaySuccessToast(
+				__('Variants generated successfully', 'wpappointments')
+			);
+		}
+
+		return response;
+	}
+
+	async function getBookableTypes() {
+		const [error, response] = await resolve<TypesResponse>(async () => {
+			return await apiFetch<TypesResponse>({ path: 'bookable-types' });
+		});
+
+		if (error) {
+			handleError(
+				error,
+				__('Error fetching bookable types', 'wpappointments')
+			);
+			return [];
+		}
+
+		return response?.data?.types ?? [];
+	}
+
+	async function getVariantAvailability(
+		variantId: number,
+		startDate?: string,
+		endDate?: string
+	) {
+		const query = new URLSearchParams();
+		if (startDate) query.set('start_date', startDate);
+		if (endDate) query.set('end_date', endDate);
+
+		const path = query.toString()
+			? `bookable-availability/${variantId}?${query.toString()}`
+			: `bookable-availability/${variantId}`;
+
+		const [error, response] = await resolve<AvailabilityResponse>(
+			async () => {
+				return await apiFetch<AvailabilityResponse>({ path });
+			}
+		);
+
+		if (error) {
+			handleError(
+				error,
+				__('Error fetching availability', 'wpappointments')
+			);
+			return null;
+		}
+
+		return response;
+	}
+
+	function handleError(error: Error, message: string) {
+		displayErrorToast(`${message}: ${getErrorMessage(error)}`);
+		console.error('Error: ' + getErrorMessage(error));
+	}
+
+	return {
+		getBookables,
+		createBookable,
+		updateBookable,
+		deleteBookable,
+		getVariants,
+		createVariant,
+		updateVariant,
+		deleteVariant,
+		generateVariants,
+		getBookableTypes,
+		getVariantAvailability,
+	};
+}
+
+export type BookablesApi = ReturnType<typeof bookablesApi>;

--- a/plugins/wpappointments/assets/backend/schemas.ts
+++ b/plugins/wpappointments/assets/backend/schemas.ts
@@ -51,6 +51,52 @@ export const ServiceSchema = object({
 	image: optional(string()),
 });
 
+export const BookableEntitySchema = object({
+	id: optional(number()),
+	name: string(),
+	active: optional(boolean()),
+	description: optional(string()),
+	type: optional(string()),
+	image: optional(string()),
+	imageId: optional(number()),
+	scheduleId: optional(number()),
+	bufferBefore: optional(number()),
+	bufferAfter: optional(number()),
+	minLeadTime: optional(number()),
+	maxLeadTime: optional(number()),
+	duration: optional(number()),
+	attributes: optional(
+		array(
+			object({
+				name: string(),
+				values: array(string()),
+			})
+		)
+	),
+});
+
+export const BookableVariantSchema = object({
+	id: optional(number()),
+	parentId: optional(number()),
+	name: optional(string()),
+	active: optional(boolean()),
+	attributeValues: optional(object({})),
+	overrides: optional(array(string())),
+	duration: optional(number()),
+	scheduleId: optional(number()),
+	bufferBefore: optional(number()),
+	bufferAfter: optional(number()),
+	minLeadTime: optional(number()),
+	maxLeadTime: optional(number()),
+});
+
+export const BookableTypeSchema = object({
+	slug: string(),
+	label: string(),
+	fields: optional(object({})),
+	variantOverridableFields: optional(array(string())),
+});
+
 export const EntitySchema = object({
 	id: optional(number()),
 	name: string(),

--- a/plugins/wpappointments/assets/backend/store/actions.ts
+++ b/plugins/wpappointments/assets/backend/store/actions.ts
@@ -1,6 +1,7 @@
 import { APIFetchOptions } from '@wordpress/api-fetch';
 import { actions as appointments } from './appointments/appointments';
 import { actions as availability } from './availability/availability';
+import { actions as bookables } from './bookables/bookables';
 import { actions as customers } from './customers/customers';
 import { actions as entities } from './entities/entities';
 import { actions as notices } from './notices/notices';
@@ -34,4 +35,5 @@ export default {
 	...customers,
 	...entities,
 	...services,
+	...bookables,
 };

--- a/plugins/wpappointments/assets/backend/store/bookables/bookables.ts
+++ b/plugins/wpappointments/assets/backend/store/bookables/bookables.ts
@@ -1,0 +1,149 @@
+import { addQueryArgs } from '@wordpress/url';
+import { produce } from 'immer';
+import apiFetch, { APIResponse } from '~/backend/utils/fetch';
+import { BookableEntity, BookableType } from '~/backend/types';
+import { FetchFromApiActionReturn, baseActions } from '../actions';
+import { type State } from '../store';
+import { type BookablesState } from './bookables.types';
+
+type Action = ReturnType<(typeof actions)[keyof typeof actions]>;
+type Query = Record<string, unknown>;
+type Response = APIResponse<BookablesState>;
+type TypesResponse = APIResponse<{ types: BookableType[] }>;
+
+export const DEFAULT_BOOKABLES_STATE: BookablesState = {
+	bookables: [],
+	types: [],
+	totalItems: 0,
+	totalPages: 1,
+	postsPerPage: 10,
+	currentPage: 1,
+};
+
+export const actions = {
+	setBookables({
+		bookables,
+		totalItems,
+		totalPages,
+		postsPerPage,
+		currentPage,
+	}: Omit<BookablesState, 'types'>) {
+		return {
+			type: 'SET_BOOKABLES',
+			bookables,
+			totalItems,
+			totalPages,
+			postsPerPage,
+			currentPage,
+		} as const;
+	},
+	createBookable(bookable: BookableEntity) {
+		return {
+			type: 'CREATE_BOOKABLE',
+			bookable,
+		} as const;
+	},
+	updateBookable(bookable: BookableEntity) {
+		return {
+			type: 'UPDATE_BOOKABLE',
+			bookable,
+		} as const;
+	},
+	deleteBookable(id: number) {
+		return {
+			type: 'DELETE_BOOKABLE',
+			id,
+		} as const;
+	},
+	setBookableTypes(types: BookableType[]) {
+		return {
+			type: 'SET_BOOKABLE_TYPES',
+			types,
+		} as const;
+	},
+};
+
+export const reducer = (state = DEFAULT_BOOKABLES_STATE, action: Action) => {
+	switch (action.type) {
+		case 'SET_BOOKABLES':
+			return produce(state, (draft) => {
+				draft.bookables = action.bookables;
+				draft.totalItems = action.totalItems;
+				draft.totalPages = action.totalPages;
+				draft.postsPerPage = action.postsPerPage;
+				draft.currentPage = action.currentPage;
+			});
+
+		case 'CREATE_BOOKABLE':
+			return produce(state, (draft) => {
+				draft.bookables.unshift(action.bookable);
+			});
+
+		case 'UPDATE_BOOKABLE':
+			return produce(state, (draft) => {
+				draft.bookables = draft.bookables.map((b: BookableEntity) =>
+					b.id === action.bookable.id ? action.bookable : b
+				);
+			});
+
+		case 'DELETE_BOOKABLE':
+			return produce(state, (draft) => {
+				draft.bookables = draft.bookables.filter(
+					(b: BookableEntity) => b.id !== action.id
+				);
+			});
+
+		case 'SET_BOOKABLE_TYPES':
+			return produce(state, (draft) => {
+				draft.types = action.types;
+			});
+
+		default:
+			return state;
+	}
+};
+
+export const selectors = {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	getBookables(state: State, _?: Query) {
+		return state.bookables;
+	},
+	getBookableTypes(state: State) {
+		return state.bookables.types;
+	},
+};
+
+export const controls = {
+	SET_BOOKABLES() {
+		return apiFetch({ path: 'bookables' });
+	},
+};
+
+export const resolvers = {
+	*getBookables(query: Query): Generator<
+		FetchFromApiActionReturn,
+		{
+			type: string;
+			bookables: BookableEntity[];
+		},
+		Response
+	> {
+		const response = yield baseActions.fetchFromAPI(
+			addQueryArgs('bookables', {
+				query,
+			})
+		);
+		const { data } = response;
+
+		return actions.setBookables(data);
+	},
+	*getBookableTypes(): Generator<
+		FetchFromApiActionReturn,
+		{ type: string; types: BookableType[] },
+		TypesResponse
+	> {
+		const response = yield baseActions.fetchFromAPI('bookable-types');
+		const { data } = response;
+		return actions.setBookableTypes(data.types);
+	},
+};

--- a/plugins/wpappointments/assets/backend/store/bookables/bookables.types.ts
+++ b/plugins/wpappointments/assets/backend/store/bookables/bookables.types.ts
@@ -1,0 +1,10 @@
+import { BookableEntity, BookableType } from '~/backend/types';
+
+export type BookablesState = {
+	bookables: BookableEntity[];
+	types: BookableType[];
+	totalItems: number;
+	totalPages: number;
+	postsPerPage: number;
+	currentPage: number;
+};

--- a/plugins/wpappointments/assets/backend/store/reducers.ts
+++ b/plugins/wpappointments/assets/backend/store/reducers.ts
@@ -1,5 +1,6 @@
 import { reducer as appointments } from './appointments/appointments';
 import { reducer as availability } from './availability/availability';
+import { reducer as bookables } from './bookables/bookables';
 import { reducer as customers } from './customers/customers';
 import { reducer as entities } from './entities/entities';
 import { reducer as notices } from './notices/notices';
@@ -18,4 +19,5 @@ export default {
 	customers,
 	entities,
 	services,
+	bookables,
 };

--- a/plugins/wpappointments/assets/backend/store/resolvers.ts
+++ b/plugins/wpappointments/assets/backend/store/resolvers.ts
@@ -1,5 +1,6 @@
 import { resolvers as appointments } from './appointments/appointments';
 import { resolvers as availability } from './availability/availability';
+import { resolvers as bookables } from './bookables/bookables';
 import { resolvers as customers } from './customers/customers';
 import { resolvers as entities } from './entities/entities';
 import { resolvers as notices } from './notices/notices';
@@ -16,4 +17,5 @@ export default {
 	...customers,
 	...entities,
 	...services,
+	...bookables,
 };

--- a/plugins/wpappointments/assets/backend/store/selectors.ts
+++ b/plugins/wpappointments/assets/backend/store/selectors.ts
@@ -1,5 +1,6 @@
 import { selectors as appointments } from './appointments/appointments';
 import { selectors as availability } from './availability/availability';
+import { selectors as bookables } from './bookables/bookables';
 import { selectors as customers } from './customers/customers';
 import { selectors as entities } from './entities/entities';
 import { selectors as notices } from './notices/notices';
@@ -18,4 +19,5 @@ export default {
 	...customers,
 	...entities,
 	...services,
+	...bookables,
 };

--- a/plugins/wpappointments/assets/backend/store/store.ts
+++ b/plugins/wpappointments/assets/backend/store/store.ts
@@ -2,6 +2,7 @@ import { combineReducers, createReduxStore } from '@wordpress/data';
 import actions from './actions';
 import { AppointmentsState } from './appointments/appointments.types';
 import { AvailabilityState } from './availability/availability.types';
+import { BookablesState } from './bookables/bookables.types';
 import controls from './controls';
 import { CustomersState } from './customers/customers.types';
 import { EntitiesState } from './entities/entities.types';
@@ -24,6 +25,7 @@ export type State = {
 	customers: CustomersState;
 	entities: EntitiesState;
 	services: ServicesState;
+	bookables: BookablesState;
 };
 
 export const store = createReduxStore('wpappointments', {

--- a/plugins/wpappointments/assets/backend/types.ts
+++ b/plugins/wpappointments/assets/backend/types.ts
@@ -2,6 +2,9 @@ import { Output } from 'valibot';
 import {
 	ApiActionSchema,
 	AppointmentSchema,
+	BookableEntitySchema,
+	BookableTypeSchema,
+	BookableVariantSchema,
 	CustomerSchema,
 	EntitySchema,
 	ServiceSchema,
@@ -9,6 +12,9 @@ import {
 
 export type ApiAction = Output<typeof ApiActionSchema>;
 export type Appointment = Output<typeof AppointmentSchema>;
+export type BookableEntity = Output<typeof BookableEntitySchema>;
+export type BookableVariant = Output<typeof BookableVariantSchema>;
+export type BookableType = Output<typeof BookableTypeSchema>;
 export type Customer = Output<typeof CustomerSchema>;
 export type Entity = Output<typeof EntitySchema>;
 export type Service = Output<typeof ServiceSchema>;


### PR DESCRIPTION
## Summary
- BookableEntity, BookableVariant, BookableType Valibot schemas and TypeScript types
- `bookablesApi()` client with CRUD for entities, variants, availability queries, type listing, and matrix generation
- `bookables` Redux store slice with actions, reducer, selectors, resolvers for `@wordpress/data`
- Wired into main store (actions, reducers, selectors, resolvers)

This provides the frontend foundation for plugins to build admin UIs for their bookable types.

## Test plan
- [ ] TypeScript compiles without errors
- [ ] ESLint passes
- [ ] Store selectors `getBookables` and `getBookableTypes` resolve via API
- [ ] API client methods call correct endpoints with proper HTTP methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: WPPoland <hello@wppoland.com>