### PR TITLE
fix: Register capabilities in test setUp to fix 20+ failing REST tests

### DIFF
--- a/tools/testing/phpunit/src/RestTestCase.php
+++ b/tools/testing/phpunit/src/RestTestCase.php
@@ -9,6 +9,7 @@ namespace TestTools;
 
 use TestTools\Factory\FactoryForAppointment;
 use TestTools\Utils\RESTServer;
+use WPAppointments\Core\Capabilities;
 
 /**
  * Abstract WordPress PHPUnit test case class
@@ -27,10 +28,32 @@ abstract class RestTestCase extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
+		$this->register_capabilities();
+
 		global $wp_rest_server;
 		$wp_rest_server = new RESTServer();
 		$this->server   = $wp_rest_server;
 		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Register custom capabilities for the administrator role.
+	 *
+	 * In the test environment the plugin activation hook is not fired,
+	 * so custom capabilities must be added manually before each test.
+	 *
+	 * @return void
+	 */
+	private function register_capabilities() {
+		$role = get_role( 'administrator' );
+
+		if ( ! $role ) {
+			return;
+		}
+
+		foreach ( Capabilities::all() as $cap ) {
+			$role->add_cap( $cap );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Plugin's custom capabilities are only added to admin role during activation, which never fires in test env
- All REST API permission_callback checks returned false (403) instead of passing
- Adds `register_capabilities()` in `RestTestCase::setUp()` to mirror activation behavior

All 244 tests now pass.

## Test plan
- [x] `pnpm test` — all 244 tests pass (previously 20+ failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: WPPoland <hello@wppoland.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure with automated administrator role capability registration during REST API test setup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->