### PR TITLE
security: Fix query injection, mass assignment, IDOR, input sanitization (#337)

### DIFF
--- a/plugins/wpappointments/src/Api/Endpoints/AppointmentsController.php
+++ b/plugins/wpappointments/src/Api/Endpoints/AppointmentsController.php
@@ -190,12 +190,12 @@ class AppointmentsController extends Controller {
 	 * @return WP_REST_Response
 	 */
 	public static function create_appointment( WP_REST_Request $request ) {
-		$date        = $request->get_param( 'date' );
-		$service     = $request->get_param( 'service' );
-		$duration    = $request->get_param( 'duration' );
+		$date        = sanitize_text_field( $request->get_param( 'date' ) );
+		$service     = sanitize_text_field( $request->get_param( 'service' ) );
+		$duration    = (int) $request->get_param( 'duration' );
 		$customer    = $request->get_param( 'customer' );
-		$customer_id = $request->get_param( 'customerId' );
-		$status      = $request->get_param( 'status' );
+		$customer_id = absint( $request->get_param( 'customerId' ) );
+		$status      = sanitize_text_field( $request->get_param( 'status' ) );
 
 		$date = rest_parse_date( get_gmt_from_date( $date ) );
 
@@ -229,9 +229,9 @@ class AppointmentsController extends Controller {
 	 * @return WP_REST_Response
 	 */
 	public static function create_appointment_public( WP_REST_Request $request ) {
-		$date           = $request->get_param( 'date' );
+		$date           = sanitize_text_field( $request->get_param( 'date' ) );
 		$customer       = $request->get_param( 'customer' );
-		$create_account = $request->get_param( 'createAccount' );
+		$create_account = (bool) $request->get_param( 'createAccount' );
 		$password       = $request->get_param( 'password' );
 
 		$date = rest_parse_date( get_gmt_from_date( $date ) );
@@ -277,13 +277,13 @@ class AppointmentsController extends Controller {
 	 * @return WP_REST_Response
 	 */
 	public static function update_appointment( WP_REST_Request $request ) {
-		$id          = $request->get_param( 'id' );
-		$date        = $request->get_param( 'date' );
-		$service     = $request->get_param( 'service' );
-		$duration    = $request->get_param( 'duration' );
-		$status      = $request->get_param( 'status' );
+		$id          = absint( $request->get_param( 'id' ) );
+		$date        = sanitize_text_field( $request->get_param( 'date' ) );
+		$service     = sanitize_text_field( $request->get_param( 'service' ) );
+		$duration    = (int) $request->get_param( 'duration' );
+		$status      = sanitize_text_field( $request->get_param( 'status' ) );
 		$customer    = $request->get_param( 'customer' );
-		$customer_id = $request->get_param( 'customerId' );
+		$customer_id = absint( $request->get_param( 'customerId' ) );
 
 		$date = rest_parse_date( get_gmt_from_date( $date ) );
 

--- a/plugins/wpappointments/src/Api/Endpoints/AvailabilityController.php
+++ b/plugins/wpappointments/src/Api/Endpoints/AvailabilityController.php
@@ -58,7 +58,15 @@ class AvailabilityController extends Controller {
 	public static function availability( WP_REST_Request $request ) {
 		$month    = $request->get_param( 'currentMonth' );
 		$year     = $request->get_param( 'currentYear' );
-		$timezone = $request->get_param( 'timezone' );
+		$timezone = sanitize_text_field( (string) $request->get_param( 'timezone' ) );
+
+		if ( is_numeric( $month ) ) {
+			$month = (int) $month;
+		}
+
+		if ( is_numeric( $year ) ) {
+			$year = (int) $year;
+		}
 
 		$availability = Availability::get_month_days_availability(
 			$month,
@@ -88,10 +96,21 @@ class AvailabilityController extends Controller {
 	 * @return WP_REST_Response
 	 */
 	public static function calendar_availability( WP_REST_Request $request ) {
-		$calendar = $request->get_param( 'calendar' );
-		$timezone = $request->get_param( 'timezone' );
-		$trim     = $request->get_param( 'trim' ) === 'true' ? true : false;
-		$calendar = json_decode( $calendar );
+		$calendar_raw = $request->get_param( 'calendar' );
+		$timezone     = sanitize_text_field( (string) $request->get_param( 'timezone' ) );
+		$trim         = $request->get_param( 'trim' ) === 'true' ? true : false;
+
+		if ( null !== $calendar_raw ) {
+			$calendar = json_decode( $calendar_raw );
+
+			if ( null === $calendar ) {
+				return self::error(
+					new \WP_Error( 'invalid_calendar', __( 'Invalid calendar data', 'wpappointments' ) )
+				);
+			}
+		} else {
+			$calendar = null;
+		}
 
 		$availability = Availability::get_month_calendar_availability( $calendar, $timezone, $trim );
 

--- a/plugins/wpappointments/src/Api/Endpoints/CustomersController.php
+++ b/plugins/wpappointments/src/Api/Endpoints/CustomersController.php
@@ -107,9 +107,9 @@ class CustomersController extends Controller {
 	 * @return WP_REST_Response
 	 */
 	public static function create( WP_REST_Request $request ) {
-		$name     = $request->get_param( 'name' );
-		$email    = $request->get_param( 'email' );
-		$phone    = $request->get_param( 'phone' );
+		$name     = sanitize_text_field( $request->get_param( 'name' ) );
+		$email    = sanitize_email( $request->get_param( 'email' ) );
+		$phone    = sanitize_text_field( $request->get_param( 'phone' ) );
 		$password = $request->get_param( 'password' );
 
 		$customer       = new Customer(
@@ -142,10 +142,10 @@ class CustomersController extends Controller {
 	 * @return WP_REST_Response
 	 */
 	public static function update( WP_REST_Request $request ) {
-		$id    = $request->get_param( 'id' );
-		$name  = $request->get_param( 'name' );
-		$email = $request->get_param( 'email' );
-		$phone = $request->get_param( 'phone' );
+		$id    = absint( $request->get_param( 'id' ) );
+		$name  = sanitize_text_field( $request->get_param( 'name' ) );
+		$email = sanitize_email( $request->get_param( 'email' ) );
+		$phone = sanitize_text_field( $request->get_param( 'phone' ) );
 
 		$customer         = new Customer( $id );
 		$updated_customer = $customer->update(

--- a/plugins/wpappointments/src/Data/Model/Appointment.php
+++ b/plugins/wpappointments/src/Data/Model/Appointment.php
@@ -305,8 +305,14 @@ class Appointment {
 			return new \WP_Error( 'appointment_id_required', __( 'Appointment ID is required', 'wpappointments' ) );
 		}
 
-		if ( ! get_post( $post_id ) ) {
+		$post = get_post( $post_id );
+
+		if ( ! $post ) {
 			return new \WP_Error( 'appointment_not_found', __( 'Appointment not found', 'wpappointments' ) );
+		}
+
+		if ( 'wpa-appointment' !== $post->post_type ) {
+			return new \WP_Error( 'appointment_invalid_type', __( 'Post is not an appointment', 'wpappointments' ) );
 		}
 
 		return $post_id;

--- a/plugins/wpappointments/src/Data/Model/Entity.php
+++ b/plugins/wpappointments/src/Data/Model/Entity.php
@@ -91,6 +91,10 @@ class Entity {
 		unset( $meta['name'] );
 		unset( $meta['parent_id'] );
 
+		// Filter meta against allowed fields to prevent mass assignment.
+		$allowed_meta_keys = array_diff( self::FIELDS, array( 'name' ) );
+		$meta              = array_intersect_key( $meta, array_flip( $allowed_meta_keys ) );
+
 		$post_id = wp_insert_post(
 			array(
 				'post_type'   => PluginInfo::POST_TYPES['entity'],
@@ -159,6 +163,10 @@ class Entity {
 		$meta = $data;
 		unset( $meta['name'] );
 		unset( $meta['parent_id'] );
+
+		// Filter meta against allowed fields to prevent mass assignment.
+		$allowed_meta_keys = array_diff( self::FIELDS, array( 'name' ) );
+		$meta              = array_intersect_key( $meta, array_flip( $allowed_meta_keys ) );
 
 		$post_data['meta_input'] = $meta;
 

--- a/plugins/wpappointments/src/Data/Model/Service.php
+++ b/plugins/wpappointments/src/Data/Model/Service.php
@@ -94,6 +94,10 @@ class Service {
 		$category = $meta['category'] ?? null;
 		unset( $meta['category'] );
 
+		// Filter meta against allowed fields to prevent mass assignment.
+		$allowed_meta_keys = array_diff( self::FIELDS, array( 'name', 'category' ) );
+		$meta              = array_intersect_key( $meta, array_flip( $allowed_meta_keys ) );
+
 		$post_id = wp_insert_post(
 			array(
 				'post_type'   => PluginInfo::POST_TYPES['service'],
@@ -148,6 +152,11 @@ class Service {
 
 		$meta = $data;
 		unset( $meta['category'] );
+		unset( $meta['name'] );
+
+		// Filter meta against allowed fields to prevent mass assignment.
+		$allowed_meta_keys = array_diff( self::FIELDS, array( 'name', 'category' ) );
+		$meta              = array_intersect_key( $meta, array_flip( $allowed_meta_keys ) );
 
 		$updated = wp_update_post(
 			array(
@@ -381,8 +390,14 @@ class Service {
 			return new WP_Error( 'service_id_required', __( 'Service ID is required', 'wpappointments' ) );
 		}
 
-		if ( ! get_post( $post_id ) ) {
+		$post = get_post( $post_id );
+
+		if ( ! $post ) {
 			return new WP_Error( 'service_not_found', __( 'Service not found', 'wpappointments' ) );
+		}
+
+		if ( PluginInfo::POST_TYPES['service'] !== $post->post_type ) {
+			return new WP_Error( 'service_invalid_type', __( 'Post is not a service', 'wpappointments' ) );
 		}
 
 		return $post_id;

--- a/plugins/wpappointments/src/Data/Model/Settings.php
+++ b/plugins/wpappointments/src/Data/Model/Settings.php
@@ -188,8 +188,21 @@ class Settings {
 
 		$updated = array();
 
+		// Build list of allowed setting names for this category.
+		$allowed_keys = array_map(
+			function ( $option ) {
+				return $option['name'];
+			},
+			$this->settings[ $category ]
+		);
+
 		if ( $category_exists ) {
 			foreach ( $settings as $key => $value ) {
+				// Skip keys not defined in the settings schema.
+				if ( ! in_array( $key, $allowed_keys, true ) ) {
+					continue;
+				}
+
 				if ( 'serviceName' === $key ) {
 					$service_post_id = get_option( 'wpappointments_defaultServiceId' );
 

--- a/plugins/wpappointments/src/Data/Query/AppointmentsQuery.php
+++ b/plugins/wpappointments/src/Data/Query/AppointmentsQuery.php
@@ -43,21 +43,49 @@ class AppointmentsQuery {
 	 */
 	public static function all( $query ) {
 		$appointments   = array();
-		$posts_per_page = $query['posts_per_page'] ?? 10;
-		$default_query  = array_merge(
+		$query          = is_array( $query ) ? $query : array();
+		$posts_per_page = isset( $query['posts_per_page'] ) ? absint( $query['posts_per_page'] ) : 10;
+		$paged          = isset( $query['paged'] ) ? absint( $query['paged'] ) : 1;
+
+		$args = array_merge(
 			self::DEFAULT_QUERY_PART,
 			array(
 				'posts_per_page' => $posts_per_page,
+				'paged'          => $paged,
 				'meta_query'     => array(),
 			)
 		);
 
-		$query = new WP_Query(
-			array_merge(
-				$default_query,
-				(array) $query
-			)
-		);
+		if ( ! empty( $query['status'] ) ) {
+			$allowed_statuses = array( 'pending', 'confirmed', 'cancelled' );
+			$status           = sanitize_text_field( $query['status'] );
+
+			if ( in_array( $status, $allowed_statuses, true ) ) {
+				$args['meta_query'][] = array(
+					'key'     => 'status',
+					'value'   => $status,
+					'compare' => '=',
+				);
+			}
+		}
+
+		if ( ! empty( $query['date_from'] ) ) {
+			$args['meta_query'][] = array(
+				'key'     => 'timestamp',
+				'value'   => (int) $query['date_from'],
+				'compare' => '>=',
+			);
+		}
+
+		if ( ! empty( $query['date_to'] ) ) {
+			$args['meta_query'][] = array(
+				'key'     => 'timestamp',
+				'value'   => (int) $query['date_to'],
+				'compare' => '<=',
+			);
+		}
+
+		$query = new WP_Query( $args );
 
 		foreach ( $query->posts as $post ) {
 			$appointments[] = self::normalize(
@@ -83,6 +111,10 @@ class AppointmentsQuery {
 	 * @return array
 	 */
 	public static function upcoming( $query ) {
+		$query          = is_array( $query ) ? $query : array();
+		$posts_per_page = isset( $query['posts_per_page'] ) ? absint( $query['posts_per_page'] ) : 10;
+		$paged          = isset( $query['paged'] ) ? absint( $query['paged'] ) : 1;
+
 		$date_query = array(
 			array(
 				'key'     => 'timestamp',
@@ -102,10 +134,11 @@ class AppointmentsQuery {
 			'compare' => '=',
 		);
 
-		$default_query = array_merge(
+		$args = array_merge(
 			self::DEFAULT_QUERY_PART,
 			array(
-				'posts_per_page' => 10,
+				'posts_per_page' => $posts_per_page,
+				'paged'          => $paged,
 				'meta_query'     => array_merge(
 					array(
 						'relation' => 'AND',
@@ -116,12 +149,7 @@ class AppointmentsQuery {
 			),
 		);
 
-		$query = new \WP_Query(
-			array_merge(
-				$default_query,
-				$query ?? array()
-			)
-		);
+		$query = new \WP_Query( $args );
 
 		$appointments = array();
 

--- a/plugins/wpappointments/src/Data/Query/CustomersQuery.php
+++ b/plugins/wpappointments/src/Data/Query/CustomersQuery.php
@@ -40,12 +40,27 @@ class CustomersQuery {
 	 * @param array $query Query params.
 	 */
 	public static function all( $query = array() ) {
-		$user_query = new WP_User_Query(
-			array_merge(
-				self::DEFAULT_QUERY_PART,
-				$query
-			)
-		);
+		$query = is_array( $query ) ? $query : array();
+
+		$args = self::DEFAULT_QUERY_PART;
+
+		if ( isset( $query['paged'] ) ) {
+			$args['paged'] = absint( $query['paged'] );
+		}
+
+		if ( isset( $query['number'] ) ) {
+			$args['number'] = absint( $query['number'] );
+		}
+
+		if ( ! empty( $query['search'] ) ) {
+			$args['search']         = '*' . sanitize_text_field( $query['search'] ) . '*';
+			$args['search_columns'] = array( 'user_login', 'user_email', 'display_name' );
+		}
+
+		// Hardcode role — never allow user input to override this.
+		$args['role'] = self::ROLE;
+
+		$user_query = new WP_User_Query( $args );
 
 		$users = array();
 


### PR DESCRIPTION
## Summary
- **Query injection (HIGH):** AppointmentsQuery and CustomersQuery no longer merge raw user input into WP_Query/WP_User_Query — only allowed params extracted
- **Mass assignment (HIGH):** Service, Entity, Settings filter input against declared FIELDS before writing
- **IDOR (HIGH):** Appointment.validate_post_id() checks post_type to prevent cross-CPT operations
- **Input sanitization (HIGH):** All controllers sanitize at entry (sanitize_text_field, sanitize_email, absint)

Fixes 8 HIGH severity findings from security audit. Refs #337.

## Test plan
- [ ] Existing tests pass (no regressions)
- [ ] Verify unknown fields in POST body are rejected (not written to meta)
- [ ] Verify appointment endpoints reject non-appointment post IDs
- [ ] Verify customer query cannot override role param

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: WPPoland <hello@wppoland.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation and sanitization across API endpoints to enhance security and data integrity.
  * Added stricter post-type validation for appointment and service records.
  * Restricted meta-key assignments to schema-defined fields, preventing unauthorized data writes.
  * Enhanced error handling for invalid calendar data and improved query filtering with pagination support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->