### PR TITLE
feat: Add Gutenberg block extensibility hooks for addon plugins

### DIFF
--- a/plugins/wpappointments/assets/backend/utils/hooks.ts
+++ b/plugins/wpappointments/assets/backend/utils/hooks.ts
@@ -1,3 +1,7 @@
-export function applyFilters<T>(name: string, value: T): T {
-	return window.wpappointments.hooks.applyFilters(name, value) as T;
+export function applyFilters<T>(name: string, value: T, ...args: unknown[]): T {
+	return window.wpappointments.hooks.applyFilters(name, value, ...args) as T;
+}
+
+export function doAction(name: string, ...args: unknown[]): void {
+	window.wpappointments.hooks.doAction(name, ...args);
 }

--- a/plugins/wpappointments/assets/frontend/components/BookingFlow/BookingFlow.tsx
+++ b/plugins/wpappointments/assets/frontend/components/BookingFlow/BookingFlow.tsx
@@ -1,3 +1,4 @@
+import { applyFilters } from '~/backend/utils/hooks';
 import BookingFlowMultiStep from './BookingFlowMultStep/BookingFlowMultiStep';
 import BookingFlowSingleStep from './BookingFlowSingleStep/BookingFlowSingleStep';
 import { useBookingFlowContext } from '~/frontend/context/BookingFlowContext';
@@ -6,9 +7,12 @@ export default function BookingFlow() {
 	const { attributes } = useBookingFlowContext();
 	const { flowType } = attributes;
 
-	if (flowType === 'OneStep') {
-		return <BookingFlowSingleStep />;
-	}
+	const FlowComponent = applyFilters<React.ComponentType>(
+		'wpappointments.bookingFlow.component',
+		flowType === 'OneStep' ? BookingFlowSingleStep : BookingFlowMultiStep,
+		flowType,
+		attributes
+	);
 
-	return <BookingFlowMultiStep />;
+	return <FlowComponent />;
 }

--- a/plugins/wpappointments/assets/gutenberg/blocks/booking-flow/src/edit.tsx
+++ b/plugins/wpappointments/assets/gutenberg/blocks/booking-flow/src/edit.tsx
@@ -18,6 +18,7 @@ import {
 	positionRight,
 	stretchFullWidth,
 } from '@wordpress/icons';
+import { applyFilters } from '~/backend/utils/hooks';
 import type { BookingFlowBlockAttributes } from './booking-flow-block';
 import BookingFlow from '~/frontend/frontend';
 
@@ -143,6 +144,12 @@ export default function Edit({
 						</ButtonGroup>
 					</PanelBody>
 				</Panel>
+				{applyFilters<React.JSX.Element | null>(
+					'wpappointments.bookingFlow.inspectorControls',
+					null,
+					attributes,
+					setAttributes
+				)}
 			</InspectorControls>
 		</div>
 	);

--- a/plugins/wpappointments/assets/gutenberg/blocks/booking-flow/src/render.php
+++ b/plugins/wpappointments/assets/gutenberg/blocks/booking-flow/src/render.php
@@ -6,12 +6,30 @@
  * @since 0.0.1
  */
 
+/**
+ * Filter block attributes before rendering.
+ *
+ * Allows addons to modify block attributes (e.g., add custom fields,
+ * change defaults) before the booking flow is rendered.
+ *
+ * @param array $attributes Block attributes.
+ */
+$attributes = apply_filters( 'wpappointments_booking_flow_attributes', $attributes );
+
 $element = sprintf(
 	"<div class='wpappointments-booking-flow' data-attributes='%s'></div>",
 	base64_encode( wp_json_encode( $attributes ) )
 );
 
-printf(
+/**
+ * Filter the booking flow block HTML output.
+ *
+ * Allows addons to wrap or modify the rendered block output.
+ *
+ * @param string $output     The rendered block HTML.
+ * @param array  $attributes Block attributes.
+ */
+$block_output = sprintf(
 	'<div %s>%s</div>',
 	esc_attr( get_block_wrapper_attributes() ),
 	wp_kses(
@@ -24,3 +42,5 @@ printf(
 		)
 	)
 );
+
+echo apply_filters( 'wpappointments_booking_flow_output', $block_output, $attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped


### PR DESCRIPTION
## Summary
- **PHP filters**: `wpappointments_booking_flow_attributes` (modify block attrs before render), `wpappointments_booking_flow_output` (filter rendered HTML)
- **JS filters**: `wpappointments.bookingFlow.inspectorControls` (add custom block settings panels), `wpappointments.bookingFlow.component` (replace/wrap booking flow component)
- Updated `applyFilters` utility to support variadic args, added `doAction` helper

Enables addon plugins to extend the booking flow block without modifying core.

## Test plan
- [ ] Block renders normally without any filters registered
- [ ] PHP: `add_filter('wpappointments_booking_flow_attributes', ...)` modifies attributes
- [ ] JS: `wp.hooks.addFilter('wpappointments.bookingFlow.inspectorControls', ...)` adds panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: WPPoland <hello@wppoland.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced booking flow component with customization hooks, enabling flexible step layouts and output filtering
  * Added filter extension points in the booking flow block editor for custom inspector controls
  * Introduced action hook support for extended functionality

* **Chores**
  * Refactored internal hook system to support variadic arguments for broader extensibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->