### PR TITLE
fix: Add booking flow hooks and fix hardcoded error string

### DIFF
--- a/plugins/wpappointments/assets/frontend/context/BookingFlowContext.tsx
+++ b/plugins/wpappointments/assets/frontend/context/BookingFlowContext.tsx
@@ -1,9 +1,11 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useLilius } from 'use-lilius';
 import { safeParse } from 'valibot';
 import apiFetch, { APIResponse } from '~/backend/utils/fetch';
+import { applyFilters, doAction } from '~/backend/utils/hooks';
 import { formatTime, getWeekDays } from '~/backend/utils/i18n';
 import resolve from '~/backend/utils/resolve';
 import { Appointment, Customer } from '~/backend/types';
@@ -129,28 +131,36 @@ export function BookingFlowContextProvider({
 			phone: data.phone,
 		};
 
+		const appointmentData = applyFilters(
+			'wpappointments.bookingFlow.appointmentData',
+			{
+				customer,
+				date: data.datetime,
+				createAccount: data.account,
+				password: data.password,
+			},
+			data
+		);
+
+		doAction('wpappointments.bookingFlow.beforeSubmit', appointmentData);
+
 		const [error, response] = await resolve<Response>(async () => {
-			const response = await apiFetch<Response>({
+			return await apiFetch<Response>({
 				path: 'public/appointments',
 				method: 'POST',
-				data: {
-					customer,
-					date: data.datetime,
-					createAccount: data.account,
-					password: data.password,
-				},
+				data: appointmentData,
 			});
-
-			return response;
 		});
 
 		if (error) {
-			setFormError('Error creating appointment');
+			setFormError(__('Error creating appointment', 'wpappointments'));
+			doAction('wpappointments.bookingFlow.submitError', error);
 		}
 
 		if (response) {
 			if (response.status === 'success') {
 				setFormSuccess(true);
+				doAction('wpappointments.bookingFlow.submitSuccess', response);
 			}
 
 			if (response.status === 'error' && response.message) {


### PR DESCRIPTION
## Summary
- **wpappointments.bookingFlow.appointmentData** filter: modify booking data before submit (addon plugins can inject variant_id, custom fields)
- **wpappointments.bookingFlow.beforeSubmit** action: fires before API call
- **wpappointments.bookingFlow.submitSuccess/Error** actions: fires on result
- Wrap hardcoded error message in `__()` for i18n

Critical for addon plugins that need to inject variant selection into the booking flow.

## Test plan
- [ ] Booking flow still creates appointments without any filters
- [ ] Filter can modify appointment data before submission
- [ ] Error message appears translated when locale changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: WPPoland <hello@wppoland.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Appointment creation error messages now display localized, user-friendly text instead of generic errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->