### PR TITLE
perf: remove wp-components from frontend, fix CLS

### DIFF
--- a/plugins/wpappointments/assets/frontend/components/BookingFlow/BookingFlowCalendar/BookingFlowCalendar.tsx
+++ b/plugins/wpappointments/assets/frontend/components/BookingFlow/BookingFlowCalendar/BookingFlowCalendar.tsx
@@ -1,6 +1,4 @@
-import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { addDays, addMinutes, addYears, format } from 'date-fns';
 import cn from 'obj-str';
 import { formatTime } from '~/backend/utils/i18n';
@@ -57,7 +55,15 @@ export default function BookingFlowCalendar() {
 						}
 						className={styles.calendarControlButton}
 					>
-						<Icon icon={chevronLeft} />
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							viewBox="0 0 24 24"
+							width="24"
+							height="24"
+							aria-hidden="true"
+						>
+							<path d="M14.6 7l-1.2-1L8 12l5.4 6 1.2-1-4.6-5z" />
+						</svg>
 					</button>
 					<h5 className={styles.calendarMonthHeader}>
 						{currentMonth} {currentYear}
@@ -67,7 +73,15 @@ export default function BookingFlowCalendar() {
 						type="button"
 						className={styles.calendarControlButton}
 					>
-						<Icon icon={chevronRight} />
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							viewBox="0 0 24 24"
+							width="24"
+							height="24"
+							aria-hidden="true"
+						>
+							<path d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1L16 12z" />
+						</svg>
 					</button>
 				</div>
 				<div className={styles.calendarHeader}>

--- a/plugins/wpappointments/assets/gutenberg/blocks/booking-flow/src/render.php
+++ b/plugins/wpappointments/assets/gutenberg/blocks/booking-flow/src/render.php
@@ -16,8 +16,9 @@
  */
 $attributes = apply_filters( 'wpappointments_booking_flow_attributes', $attributes );
 
+// min-height prevents CLS while React hydrates the booking flow.
 $element = sprintf(
-	"<div class='wpappointments-booking-flow' data-attributes='%s'></div>",
+	"<div class='wpappointments-booking-flow' style='min-height:400px' data-attributes='%s'></div>",
 	base64_encode( wp_json_encode( $attributes ) )
 );
 
@@ -37,6 +38,7 @@ $block_output = sprintf(
 		array(
 			'div' => array(
 				'class'           => array(),
+				'style'           => array(),
 				'data-attributes' => array(),
 			),
 		)


### PR DESCRIPTION
## Summary
Lighthouse audit on the booking page scored 32/100. Two root causes fixed:

**1. wp-components dependency chain on public pages (~500KB eliminated)**

The booking flow view script listed `wp-components` as a dependency, which pulled in `wp-compose`, `wp-data`, `moment.js`, `wp-rich-text`, and ~20 other scripts. The only actual usage was two chevron icons in `BookingFlowCalendar`. Replaced with inline SVGs.

Before: 33 JS files loaded on booking page
After: ~15 JS files

**2. CLS 0.519 from React hydration**

Empty server-rendered `<div>` expands when React mounts the calendar. Added `min-height:400px` placeholder to prevent layout shift.

### Dependency changes
```
Before: react, wp-api-fetch, wp-components, wp-element, wp-hooks, wp-i18n, wp-primitives, wp-url
After:  react, wp-api-fetch, wp-element, wp-hooks, wp-i18n, wp-url
```

Part of Epic #298

## Test plan
- [x] Booking flow renders correctly (chevron icons display)
- [x] Build passes, no wp-components import in frontend
- [ ] Lighthouse re-test shows improved score