### PR TITLE
feat(core): pre-flight extension seams for Pro addons

### DIFF
--- a/plugins/appstip-appointments/src/Api/Endpoints/OutOfOfficeController.php
+++ b/plugins/appstip-appointments/src/Api/Endpoints/OutOfOfficeController.php
@@ -342,16 +342,40 @@ class OutOfOfficeController extends Controller {
 	}
 
 	/**
-	 * Verify the current user owns the OOO entry
+	 * Verify the current user is authorised to manage the OOO entry
+	 *
+	 * By default only the user the entry belongs to passes. Addons (e.g. the
+	 * Employees Pro module's manager scope) can extend the allowed-user list
+	 * via the `wpappointments_ooo_allowed_user_ids` filter.
 	 *
 	 * @param int $entry_id OOO entry post ID.
 	 *
-	 * @return true|\WP_Error True on success, WP_Error if not the owner.
+	 * @return true|\WP_Error True on success, WP_Error if not authorised.
 	 */
 	private static function verify_entry_owner( $entry_id ) {
-		$owner_id = absint( get_post_meta( $entry_id, 'user_id', true ) );
+		$owner_id   = absint( get_post_meta( $entry_id, 'user_id', true ) );
+		$current_id = get_current_user_id();
 
-		if ( get_current_user_id() !== $owner_id ) {
+		/**
+		 * Filter the user IDs allowed to manage a given OOO entry.
+		 *
+		 * Defaults to just the entry's owner. Addons can append IDs to
+		 * authorise additional users (e.g. employees' direct manager).
+		 *
+		 * @since 0.3.0
+		 *
+		 * @param int[] $allowed_user_ids Defaults to [ $owner_id ].
+		 * @param int   $entry_id         OOO entry post ID.
+		 * @param int   $current_id       Current user's ID (already known to the caller).
+		 */
+		$allowed = apply_filters(
+			'wpappointments_ooo_allowed_user_ids',
+			array( $owner_id ),
+			$entry_id,
+			$current_id
+		);
+
+		if ( ! in_array( $current_id, array_map( 'absint', (array) $allowed ), true ) ) {
 			return new WP_Error(
 				'ooo_forbidden',
 				__( 'You do not own this time off entry.', 'appstip-appointments' ),

--- a/plugins/appstip-appointments/src/Availability/AvailabilityEngine.php
+++ b/plugins/appstip-appointments/src/Availability/AvailabilityEngine.php
@@ -42,23 +42,33 @@ class AvailabilityEngine {
 	 * Walks through all registered availability layers to compute
 	 * the final effective availability for a given variant and date range.
 	 *
-	 * @param int   $variant_id Bookable variant post ID.
-	 * @param array $date_range Array with 'start' and 'end' date strings (Y-m-d).
+	 * Optional `$extra_context` lets callers pass additional keys that
+	 * registered layers may use (e.g. `employee_id` for the Employees Pro
+	 * module's per-employee narrowing layer). Core layers ignore unknown
+	 * keys, so the parameter is safe to extend.
+	 *
+	 * @param int   $variant_id    Bookable variant post ID.
+	 * @param array $date_range    Array with 'start' and 'end' date strings (Y-m-d).
+	 * @param array $extra_context Optional extra context merged into the layer context.
+	 *                              Reserved keys (variant_id, entity_id, date_range) cannot be overridden.
 	 *
 	 * @return array Availability data in standardized format.
 	 */
-	public static function get_effective_availability( $variant_id, $date_range = array() ) {
+	public static function get_effective_availability( $variant_id, $date_range = array(), $extra_context = array() ) {
 		$variant_post = get_post( $variant_id );
 
 		if ( ! $variant_post ) {
 			return self::empty_availability();
 		}
 
-		// Build context for layer callbacks.
-		$context = array(
-			'variant_id' => $variant_id,
-			'entity_id'  => $variant_post->post_parent,
-			'date_range' => $date_range,
+		// Build context for layer callbacks. Reserved keys win over caller-supplied extras.
+		$context = array_merge(
+			is_array( $extra_context ) ? $extra_context : array(),
+			array(
+				'variant_id' => $variant_id,
+				'entity_id'  => $variant_post->post_parent,
+				'date_range' => $date_range,
+			)
 		);
 
 		// Get all registered layers sorted by priority.

--- a/plugins/appstip-appointments/src/Notifications/Notifications.php
+++ b/plugins/appstip-appointments/src/Notifications/Notifications.php
@@ -42,11 +42,15 @@ class Notifications extends Singleton {
 	 *
 	 * Built lazily so __() runs after load_textdomain().
 	 *
+	 * Filterable via `wpappointments_notification_events` so addons can
+	 * register their own events (e.g. employee_assigned in the Employees
+	 * Pro module).
+	 *
 	 * @return array
 	 */
 	public static function get_events() {
 		if ( null === self::$events ) {
-			self::$events = array(
+			$events = array(
 				'created'   => array(
 					'title'           => __( 'Appointment Created', 'appstip-appointments' ),
 					'description'     => __( 'Sent when a new appointment is booked.', 'appstip-appointments' ),
@@ -80,6 +84,20 @@ class Notifications extends Singleton {
 					'customerBody'    => __( "Dear {customer_name},\n\nYour appointment on {date} at {time} has been cancelled.\n\nIf this was a mistake, please contact us at {admin_email} to reschedule.\n\nBest regards,\n{admin_first_name} {admin_last_name}", 'appstip-appointments' ),
 				),
 			);
+
+			/**
+			 * Filter the notification event definitions.
+			 *
+			 * Lets addons register their own notification events alongside
+			 * the core ones (created/updated/confirmed/cancelled). Each entry
+			 * must follow the same shape: title, description, adminSubject,
+			 * customerSubject, adminBody, customerBody.
+			 *
+			 * @since 0.3.0
+			 *
+			 * @param array $events Map of event key => definition.
+			 */
+			self::$events = apply_filters( 'wpappointments_notification_events', $events );
 		}
 
 		return self::$events;

--- a/plugins/appstip-appointments/src/Notifications/Notifications.php
+++ b/plugins/appstip-appointments/src/Notifications/Notifications.php
@@ -97,10 +97,96 @@ class Notifications extends Singleton {
 			 *
 			 * @param array $events Map of event key => definition.
 			 */
-			self::$events = apply_filters( 'wpappointments_notification_events', $events );
+			$filtered = apply_filters( 'wpappointments_notification_events', $events );
+
+			self::$events = self::sanitize_events( $filtered, $events );
 		}
 
 		return self::$events;
+	}
+
+	/**
+	 * Required keys on every event definition.
+	 *
+	 * @var string[]
+	 */
+	private const EVENT_KEYS = array(
+		'title',
+		'description',
+		'adminSubject',
+		'customerSubject',
+		'adminBody',
+		'customerBody',
+	);
+
+	/**
+	 * Validate the shape of an event registry returned by an addon filter.
+	 *
+	 * Malformed input cannot be cached as-is — downstream dispatch reads
+	 * nested keys directly and would fatal. Drop entries that don't fit
+	 * the contract; if the whole filter returns a non-array, fall back
+	 * to the core defaults.
+	 *
+	 * @param mixed $filtered Filter output (may be anything).
+	 * @param array $defaults Core event definitions to fall back to.
+	 *
+	 * @return array Validated event registry.
+	 */
+	private static function sanitize_events( $filtered, array $defaults ) {
+		if ( ! is_array( $filtered ) ) {
+			_doing_it_wrong(
+				'apply_filters( wpappointments_notification_events )',
+				esc_html__( 'Filter must return an array of event definitions; non-array value ignored.', 'appstip-appointments' ),
+				'0.3.0'
+			);
+			return $defaults;
+		}
+
+		$valid = array();
+
+		foreach ( $filtered as $key => $definition ) {
+			if ( ! is_string( $key ) || '' === $key ) {
+				continue;
+			}
+
+			if ( ! is_array( $definition ) ) {
+				_doing_it_wrong(
+					'apply_filters( wpappointments_notification_events )',
+					sprintf(
+						/* translators: %s: event key. */
+						esc_html__( 'Event "%s" must be an array; entry dropped.', 'appstip-appointments' ),
+						esc_html( $key )
+					),
+					'0.3.0'
+				);
+				continue;
+			}
+
+			$missing = array_diff( self::EVENT_KEYS, array_keys( $definition ) );
+
+			if ( ! empty( $missing ) ) {
+				_doing_it_wrong(
+					'apply_filters( wpappointments_notification_events )',
+					sprintf(
+						/* translators: 1: event key. 2: comma-separated missing keys. */
+						esc_html__( 'Event "%1$s" is missing required keys: %2$s. Entry dropped.', 'appstip-appointments' ),
+						esc_html( $key ),
+						esc_html( implode( ', ', $missing ) )
+					),
+					'0.3.0'
+				);
+				continue;
+			}
+
+			$valid[ $key ] = $definition;
+		}
+
+		// If the filter dropped every core event without registering any valid replacement, fall back.
+		if ( empty( $valid ) ) {
+			return $defaults;
+		}
+
+		return $valid;
 	}
 
 	/**

--- a/plugins/appstip-appointments/tests/php/Api/Endpoints/OutOfOfficeControllerTest.php
+++ b/plugins/appstip-appointments/tests/php/Api/Endpoints/OutOfOfficeControllerTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Out-of-office controller — focused tests for the
+ * wpappointments_ooo_allowed_user_ids filter (the seam Pro Employees
+ * uses to authorise managers editing employee OOO).
+ *
+ * @package WPAppointments
+ */
+
+namespace Tests\Api\Endpoints;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use WPAppointments\Api\Endpoints\OutOfOfficeController;
+
+uses( \TestTools\TestCase::class )->group( 'api' );
+
+/**
+ * Invoke the private static verify_entry_owner via Reflection.
+ *
+ * @param int $entry_id Entry ID.
+ * @return true|\WP_Error
+ */
+function invoke_verify_entry_owner( $entry_id ) {
+	$method = ( new \ReflectionClass( OutOfOfficeController::class ) )->getMethod( 'verify_entry_owner' );
+	$method->setAccessible( true );
+	return $method->invoke( null, $entry_id );
+}
+
+beforeEach(
+	function () {
+		$this->owner_id    = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$this->stranger_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$this->entry_id    = self::factory()->post->create( array( 'post_type' => 'wpa-ooo' ) );
+		update_post_meta( $this->entry_id, 'user_id', $this->owner_id );
+	}
+);
+
+test(
+	'verify_entry_owner — owner is allowed by default',
+	function () {
+		wp_set_current_user( $this->owner_id );
+
+		expect( invoke_verify_entry_owner( $this->entry_id ) )->toBeTrue();
+	}
+);
+
+test(
+	'verify_entry_owner — non-owner is denied by default',
+	function () {
+		wp_set_current_user( $this->stranger_id );
+
+		$result = invoke_verify_entry_owner( $this->entry_id );
+
+		expect( $result )->toBeWPError( 'ooo_forbidden' );
+	}
+);
+
+test(
+	'verify_entry_owner — wpappointments_ooo_allowed_user_ids filter can authorise extra users',
+	function () {
+		wp_set_current_user( $this->stranger_id );
+
+		$callback = function ( $allowed, $entry_id, $current_id ) {
+			expect( $entry_id )->toBe( $this->entry_id );
+			expect( $current_id )->toBe( $this->stranger_id );
+			$allowed[] = $this->stranger_id;
+			return $allowed;
+		};
+
+		add_filter( 'wpappointments_ooo_allowed_user_ids', $callback, 10, 3 );
+
+		$result = invoke_verify_entry_owner( $this->entry_id );
+
+		expect( $result )->toBeTrue();
+
+		remove_filter( 'wpappointments_ooo_allowed_user_ids', $callback, 10 );
+	}
+);
+
+test(
+	'verify_entry_owner — filter receives the owner ID in the default allowed list',
+	function () {
+		wp_set_current_user( $this->stranger_id );
+
+		$received_allowed = null;
+
+		$callback = function ( $allowed ) use ( &$received_allowed ) {
+			$received_allowed = $allowed;
+			return $allowed;
+		};
+
+		add_filter( 'wpappointments_ooo_allowed_user_ids', $callback );
+
+		invoke_verify_entry_owner( $this->entry_id );
+
+		expect( $received_allowed )->toBe( array( $this->owner_id ) );
+
+		remove_filter( 'wpappointments_ooo_allowed_user_ids', $callback );
+	}
+);

--- a/plugins/appstip-appointments/tests/php/Availability/AvailabilityEngineTest.php
+++ b/plugins/appstip-appointments/tests/php/Availability/AvailabilityEngineTest.php
@@ -995,3 +995,97 @@ test(
 		remove_filter( 'wpappointments_effective_availability', $callback, 10 );
 	}
 );
+
+test(
+	'AvailabilityEngine - extra_context is passed to layer callbacks',
+	function () {
+		$ids = create_entity_with_variant();
+
+		$received_context = null;
+
+		AvailabilityLayerRegistry::get_instance()->register(
+			'system',
+			0,
+			array(
+				'type'     => 'base',
+				'callback' => function ( $context ) use ( &$received_context ) {
+					$received_context = $context;
+					return weekday_schedule();
+				},
+			)
+		);
+
+		AvailabilityEngine::get_effective_availability(
+			$ids['variant_id'],
+			array(
+				'start' => '2026-06-01',
+				'end'   => '2026-06-30',
+			),
+			array( 'employee_id' => 42 )
+		);
+
+		expect( $received_context )->toBeArray();
+		expect( $received_context['employee_id'] )->toBe( 42 );
+		expect( $received_context['variant_id'] )->toBe( $ids['variant_id'] );
+		expect( $received_context['date_range']['start'] )->toBe( '2026-06-01' );
+	}
+);
+
+test(
+	'AvailabilityEngine - extra_context cannot override reserved keys',
+	function () {
+		$ids = create_entity_with_variant();
+
+		$received_context = null;
+
+		AvailabilityLayerRegistry::get_instance()->register(
+			'system',
+			0,
+			array(
+				'type'     => 'base',
+				'callback' => function ( $context ) use ( &$received_context ) {
+					$received_context = $context;
+					return weekday_schedule();
+				},
+			)
+		);
+
+		AvailabilityEngine::get_effective_availability(
+			$ids['variant_id'],
+			array( 'start' => '2026-06-01' ),
+			array(
+				'variant_id' => 99999,
+				'entity_id'  => 99999,
+				'date_range' => array( 'start' => 'WRONG' ),
+				'custom_key' => 'kept',
+			)
+		);
+
+		expect( $received_context['variant_id'] )->toBe( $ids['variant_id'] );
+		expect( $received_context['date_range']['start'] )->toBe( '2026-06-01' );
+		expect( $received_context['custom_key'] )->toBe( 'kept' );
+	}
+);
+
+test(
+	'AvailabilityEngine - extra_context defaults to empty array when omitted',
+	function () {
+		$ids = create_entity_with_variant();
+
+		AvailabilityLayerRegistry::get_instance()->register(
+			'system',
+			0,
+			array(
+				'type'     => 'base',
+				'callback' => function () {
+					return weekday_schedule();
+				},
+			)
+		);
+
+		$result = AvailabilityEngine::get_effective_availability( $ids['variant_id'] );
+
+		expect( $result )->toBeArray();
+		expect( $result['weekly']['monday'][0]['start'] )->toBe( '09:00' );
+	}
+);

--- a/plugins/appstip-appointments/tests/php/Notifications/NotificationsTest.php
+++ b/plugins/appstip-appointments/tests/php/Notifications/NotificationsTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Notifications event registry — test suite
+ *
+ * @package WPAppointments
+ */
+
+namespace Tests\Notifications;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use WPAppointments\Notifications\Notifications;
+
+uses( \TestTools\TestCase::class )->group( 'notifications' );
+
+beforeEach(
+	function () {
+		// Force a rebuild of the lazy event cache so each test sees its own filter state.
+		$reflection  = new \ReflectionClass( Notifications::class );
+		$events_prop = $reflection->getProperty( 'events' );
+		$events_prop->setAccessible( true );
+		$events_prop->setValue( null, null );
+	}
+);
+
+test(
+	'Notifications - core events are present by default',
+	function () {
+		$events = Notifications::get_events();
+
+		expect( $events )->toHaveKeys( array( 'created', 'updated', 'confirmed', 'cancelled' ) );
+		expect( $events['created'] )->toHaveKeys(
+			array( 'title', 'description', 'adminSubject', 'customerSubject', 'adminBody', 'customerBody' )
+		);
+	}
+);
+
+test(
+	'Notifications - wpappointments_notification_events filter can add an event',
+	function () {
+		$callback = function ( $events ) {
+			$events['employee_assigned'] = array(
+				'title'           => 'Employee assigned',
+				'description'     => 'Sent when an appointment is assigned to an employee.',
+				'adminSubject'    => 'New booking',
+				'customerSubject' => 'Booking confirmed',
+				'adminBody'       => 'Body',
+				'customerBody'    => 'Body',
+			);
+			return $events;
+		};
+
+		add_filter( 'wpappointments_notification_events', $callback );
+
+		$events = Notifications::get_events();
+
+		expect( $events )->toHaveKey( 'employee_assigned' );
+		expect( $events['employee_assigned']['title'] )->toBe( 'Employee assigned' );
+
+		remove_filter( 'wpappointments_notification_events', $callback );
+	}
+);
+
+test(
+	'Notifications - wpappointments_notification_events filter can override an existing event',
+	function () {
+		$callback = function ( $events ) {
+			$events['created']['adminSubject'] = 'Custom subject';
+			return $events;
+		};
+
+		add_filter( 'wpappointments_notification_events', $callback );
+
+		$events = Notifications::get_events();
+
+		expect( $events['created']['adminSubject'] )->toBe( 'Custom subject' );
+
+		remove_filter( 'wpappointments_notification_events', $callback );
+	}
+);

--- a/plugins/appstip-appointments/tests/php/Notifications/NotificationsTest.php
+++ b/plugins/appstip-appointments/tests/php/Notifications/NotificationsTest.php
@@ -80,3 +80,66 @@ test(
 		remove_filter( 'wpappointments_notification_events', $callback );
 	}
 );
+
+test(
+	'Notifications - filter returning a non-array falls back to core defaults',
+	function () {
+		$callback = function () {
+			return 'not an array';
+		};
+
+		add_filter( 'wpappointments_notification_events', $callback );
+
+		// _doing_it_wrong is expected; tell WP_UnitTestCase to capture it.
+		$this->setExpectedIncorrectUsage( 'apply_filters( wpappointments_notification_events )' );
+		$events = Notifications::get_events();
+
+		expect( $events )->toHaveKeys( array( 'created', 'updated', 'confirmed', 'cancelled' ) );
+
+		remove_filter( 'wpappointments_notification_events', $callback );
+	}
+);
+
+test(
+	'Notifications - filter returning a non-array entry drops that entry',
+	function () {
+		$callback = function ( $events ) {
+			$events['bogus'] = 'string instead of array';
+			return $events;
+		};
+
+		add_filter( 'wpappointments_notification_events', $callback );
+
+		$this->setExpectedIncorrectUsage( 'apply_filters( wpappointments_notification_events )' );
+		$events = Notifications::get_events();
+
+		expect( $events )->not->toHaveKey( 'bogus' );
+		expect( $events )->toHaveKey( 'created' );
+
+		remove_filter( 'wpappointments_notification_events', $callback );
+	}
+);
+
+test(
+	'Notifications - filter entry missing required keys is dropped',
+	function () {
+		$callback = function ( $events ) {
+			$events['partial'] = array(
+				'title'       => 'Partial',
+				'description' => 'Missing the body fields.',
+				// adminSubject, customerSubject, adminBody, customerBody all missing.
+			);
+			return $events;
+		};
+
+		add_filter( 'wpappointments_notification_events', $callback );
+
+		$this->setExpectedIncorrectUsage( 'apply_filters( wpappointments_notification_events )' );
+		$events = Notifications::get_events();
+
+		expect( $events )->not->toHaveKey( 'partial' );
+		expect( $events )->toHaveKey( 'created' );
+
+		remove_filter( 'wpappointments_notification_events', $callback );
+	}
+);


### PR DESCRIPTION
## Summary

Three minimal, additive seams in the free core that the Pro addon bundle (Employees first) needs to plug into without modifying core again later. This is **task #5 / pre-flight** from the [PRO Addons + Industry Presets plan](https://github.com/wpappointments/wpappointments) — unblocks the License Manager + Catalog UI work and the Pro Employees module.

## Changes

1. **`Notifications::get_events()`** — new filter `wpappointments_notification_events`. Lets addons register their own notification events alongside the four core ones (created/updated/confirmed/cancelled). The lazy events cache is built once, then filtered before being stored.

2. **`OutOfOfficeController::verify_entry_owner()`** — new filter `wpappointments_ooo_allowed_user_ids`. Defaults to `[ $owner_id ]` so existing behaviour is unchanged when no addon touches the filter. Pro Employees uses this so a manager can manage their team's OOO entries.

3. **`AvailabilityEngine::get_effective_availability()`** — optional 3rd parameter `$extra_context`. Lets callers pass arbitrary extra keys that registered layers may consume (e.g. `employee_id`). Reserved keys (`variant_id`, `entity_id`, `date_range`) cannot be overridden by extras, so the parameter is safe to extend.

## Why these and not more

- These are the seams Pro Employees v1.0/v1.1 directly needs to hook into without later modifying core.
- The booking-flow `<Slot>` placements (also in the original pre-flight list) depend on UX decisions about where the employee picker sits — those will land in the same PR as the Pro Employees module so the slot + fill ship together.
- The `Schedule.tsx` parameterisation refactor (also in the list) is **not needed** — the underlying `ScheduleEditor({schedule, isNew})` component already accepts an arbitrary schedule prop.

## Backwards compatibility

All three changes are purely additive to public surface area; no existing core call site needs to change. The filters default to behaviour identical to today, and the new parameter is optional and defaults to an empty array.

## Test plan

- [x] PHPCS clean (\`pnpm phpcs\`)
- [ ] Pest tests pass on CI:
  - \`AvailabilityEngineTest\` — 3 new tests: extra-context passes through, reserved keys cannot be overridden, default empty when omitted
  - \`NotificationsTest\` (new file) — core events present, addon can register a new event, addon can override an existing event
  - \`OutOfOfficeControllerTest\` (new file) — owner allowed by default, stranger denied by default, filter can authorise extra users, filter receives the owner ID
- [ ] CI green (JS lint / type check / Build / PHPCS / Pest)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Out-of-office entry access control now supports filtering for extended authorization capabilities
* Notification events are now customizable via filter hooks, enabling addon extensions
* Availability calculations now accept additional contextual data for enhanced configuration

**Tests**
* Added comprehensive test coverage for authorization and notification event filtering functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wpappointments/wpappointments/pull/458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->