### PR TITLE
feat(availability): forward employee/location context to availability layers (CORE-B)

### DIFF
--- a/plugins/appstip-appointments/src/Api/Endpoints/BookableAvailabilityController.php
+++ b/plugins/appstip-appointments/src/Api/Endpoints/BookableAvailabilityController.php
@@ -92,7 +92,8 @@ class BookableAvailabilityController extends Controller {
 			'end'   => sanitize_text_field( $request->get_param( 'end_date' ) ?? '' ),
 		);
 
-		$availability = AvailabilityEngine::get_effective_availability( $variant_id, $date_range );
+		$context      = self::get_availability_context( $request );
+		$availability = AvailabilityEngine::get_effective_availability( $variant_id, $date_range, $context );
 		$buffers      = self::get_effective_buffers( $variant_id );
 
 		return self::response(
@@ -119,12 +120,13 @@ class BookableAvailabilityController extends Controller {
 			'end'   => sanitize_text_field( $request->get_param( 'end_date' ) ?? '' ),
 		);
 
+		$context  = self::get_availability_context( $request );
 		$result   = BookableVariantQuery::by_entity( $entity_id );
 		$variants = array();
 
 		foreach ( $result['variants'] as $variant_post ) {
 			$model        = new BookableVariant( $variant_post );
-			$availability = AvailabilityEngine::get_effective_availability( $variant_post->ID, $date_range );
+			$availability = AvailabilityEngine::get_effective_availability( $variant_post->ID, $date_range, $context );
 
 			$variants[] = array(
 				'variant'      => $model->normalize(),
@@ -228,8 +230,9 @@ class BookableAvailabilityController extends Controller {
 			'end'   => $last_date->format( 'Y-m-d' ),
 		);
 
+		$context             = self::get_availability_context( $request );
 		$engine_availability = $variant_id
-		? AvailabilityEngine::get_effective_availability( $variant_id, $date_range )
+		? AvailabilityEngine::get_effective_availability( $variant_id, $date_range, $context )
 		: AvailabilityEngine::empty_availability();
 
 		// Settings for slot generation.
@@ -482,6 +485,28 @@ class BookableAvailabilityController extends Controller {
 		}
 
 		return $value * $multipliers[ $unit ];
+	}
+
+	/**
+	 * Build the extra availability context from a request
+	 *
+	 * Reads optional resource selectors (`employeeId`, `locationId`) that Pro
+	 * narrowing layers consume to restrict availability to a specific employee
+	 * or location. Core layers ignore unknown keys, so passing this context is
+	 * always safe. The `wpappointments_availability_context` filter lets addons
+	 * inject further context keys without additional core changes.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return array Context array (e.g. ['employee_id' => 5, 'location_id' => 0]).
+	 */
+	private static function get_availability_context( $request ) {
+		$context = array(
+			'employee_id' => absint( $request->get_param( 'employeeId' ) ?? 0 ),
+			'location_id' => absint( $request->get_param( 'locationId' ) ?? 0 ),
+		);
+
+		return apply_filters( 'wpappointments_availability_context', $context, $request );
 	}
 
 	/**

--- a/plugins/appstip-appointments/src/Availability/functions.php
+++ b/plugins/appstip-appointments/src/Availability/functions.php
@@ -33,11 +33,13 @@ function register_availability_layer( $slug, $priority, $config ) {
  *
  * Walks through all registered layers to compute final availability.
  *
- * @param int   $variant_id Bookable variant post ID.
- * @param array $date_range Optional date range with 'start' and 'end' (Y-m-d).
+ * @param int   $variant_id    Bookable variant post ID.
+ * @param array $date_range    Optional date range with 'start' and 'end' (Y-m-d).
+ * @param array $extra_context Optional extra context merged into the layer context
+ *                             (e.g. `employee_id`, `location_id` for Pro narrowing layers).
  *
  * @return array Availability data in standardized format.
  */
-function get_effective_availability( $variant_id, $date_range = array() ) {
-	return AvailabilityEngine::get_effective_availability( $variant_id, $date_range );
+function get_effective_availability( $variant_id, $date_range = array(), $extra_context = array() ) {
+	return AvailabilityEngine::get_effective_availability( $variant_id, $date_range, $extra_context );
 }

--- a/plugins/appstip-appointments/tests/php/Api/Endpoints/BookableAvailabilityControllerTest.php
+++ b/plugins/appstip-appointments/tests/php/Api/Endpoints/BookableAvailabilityControllerTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Test the bookable availability API endpoints
+ *
+ * Focuses on the resource-context passthrough (employeeId/locationId) that Pro
+ * narrowing layers consume. The request params must reach the availability
+ * layer callbacks as `employee_id` / `location_id` context keys.
+ *
+ * @package WPAppointments
+ */
+
+namespace Tests\Api\Endpoints;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use WPAppointments\Availability\AvailabilityLayerRegistry;
+use WPAppointments\Bookable\BookableTypeRegistry;
+use WPAppointments\Data\Model\BookableEntity;
+use WPAppointments\Data\Model\BookableVariant;
+
+uses( \TestTools\RestTestCase::class )->group( 'api' );
+
+beforeEach(
+	function () {
+		AvailabilityLayerRegistry::get_instance()->reset();
+		BookableTypeRegistry::get_instance()->reset();
+	}
+);
+
+/**
+ * Helper: create a bookable entity with a variant and return the variant ID.
+ *
+ * @return int Variant post ID.
+ */
+function create_availability_variant() {
+	$entity  = new BookableEntity( array( 'name' => 'Ctx Test' ) );
+	$saved   = $entity->save();
+	$variant = new BookableVariant(
+		array(
+			'parent_id'        => $saved->bookable->ID,
+			'attribute_values' => array(),
+		)
+	);
+	$v_saved = $variant->save();
+	return $v_saved->variant->ID;
+}
+
+test(
+	'GET bookable-availability - forwards employeeId/locationId to layer context',
+	function () {
+		$variant_id = create_availability_variant();
+
+		$captured = new \stdClass();
+
+		AvailabilityLayerRegistry::get_instance()->register(
+			'test_capture',
+			99,
+			array(
+				'type'     => 'narrowing',
+				'callback' => function ( $context ) use ( $captured ) {
+					$captured->context = $context;
+					return null; // pass-through, do not narrow.
+				},
+			)
+		);
+
+		$this->do_rest_get_request(
+			'bookable-availability/' . $variant_id,
+			array(
+				'employeeId' => 5,
+				'locationId' => 7,
+			)
+		);
+
+		expect( $captured->context['employee_id'] )->toBe( 5 );
+		expect( $captured->context['location_id'] )->toBe( 7 );
+	}
+);
+
+test(
+	'GET bookable-availability - missing selectors default to 0',
+	function () {
+		$variant_id = create_availability_variant();
+
+		$captured = new \stdClass();
+
+		AvailabilityLayerRegistry::get_instance()->register(
+			'test_capture',
+			99,
+			array(
+				'type'     => 'narrowing',
+				'callback' => function ( $context ) use ( $captured ) {
+					$captured->context = $context;
+					return null;
+				},
+			)
+		);
+
+		$this->do_rest_get_request( 'bookable-availability/' . $variant_id );
+
+		expect( $captured->context['employee_id'] )->toBe( 0 );
+		expect( $captured->context['location_id'] )->toBe( 0 );
+	}
+);
+
+test(
+	'wpappointments_availability_context filter can inject extra context keys',
+	function () {
+		$variant_id = create_availability_variant();
+
+		$captured = new \stdClass();
+
+		AvailabilityLayerRegistry::get_instance()->register(
+			'test_capture',
+			99,
+			array(
+				'type'     => 'narrowing',
+				'callback' => function ( $context ) use ( $captured ) {
+					$captured->context = $context;
+					return null;
+				},
+			)
+		);
+
+		$filter = function ( $context ) {
+			$context['custom_key'] = 'abc';
+			return $context;
+		};
+		add_filter( 'wpappointments_availability_context', $filter );
+
+		$this->do_rest_get_request( 'bookable-availability/' . $variant_id );
+
+		remove_filter( 'wpappointments_availability_context', $filter );
+
+		expect( $captured->context['custom_key'] )->toBe( 'abc' );
+	}
+);


### PR DESCRIPTION
## What

Forwards an optional resource context (`employeeId` / `locationId`) from the public `bookable-availability` REST endpoints, through `get_effective_availability()`, into the registered availability layer callbacks. This is the core seam that lets Pro narrowing layers restrict availability to a **specific employee** or **specific location** at booking time.

## Why

The availability engine already accepts `$extra_context` (added in #458), but nothing was passing it from the REST layer — so per-employee / per-location booking was impossible without a core change. This is the first of two small core PRs unblocking the next wave of Pro addons (per-employee schedules, locations, assignment).

## Changes

- `src/Availability/functions.php` — `get_effective_availability()` helper now accepts and forwards `$extra_context` (matching the engine signature).
- `src/Api/Endpoints/BookableAvailabilityController.php` — new private `get_availability_context()` reads `employeeId`/`locationId` request params and exposes a `wpappointments_availability_context` filter so addons can inject further context keys; wired into all three availability reads (variant, entity, calendar-slots).
- Tests — new `BookableAvailabilityControllerTest` covering REST → controller → engine → layer context passthrough, the default-to-0 behaviour, and the context filter.

## Notes

- **Additive only.** Core layers ignore unknown context keys; no behaviour change when no Pro layer is registered.
- Stacked on `feat/pre-flight-refactors-for-pro` (#458) because it depends on the engine `$extra_context` seam introduced there. Retarget to `main` once #458 merges.

## Tests

`pest --group=api` (107 passed) and `pest --group=availability` (28 passed) green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Availability checks now support filtering by employee and location request parameters. The availability context is automatically forwarded through the system, and administrators can extend it with custom context using filters for advanced filtering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->