### PR TITLE
feat(appointments): multi-day/all-day time model + booking seams (CORE-A)

### DIFF
--- a/plugins/appstip-appointments/src/Api/Endpoints/AppointmentsController.php
+++ b/plugins/appstip-appointments/src/Api/Endpoints/AppointmentsController.php
@@ -236,6 +236,31 @@ class AppointmentsController extends Controller {
 			$meta['entity_id'] = $entity_id;
 		}
 
+		$end_timestamp = self::parse_end_timestamp( $request, $date );
+
+		if ( is_wp_error( $end_timestamp ) ) {
+			return self::error( $end_timestamp );
+		}
+
+		if ( null !== $end_timestamp ) {
+			$meta['end_timestamp'] = $end_timestamp;
+		}
+
+		if ( rest_sanitize_boolean( $request->get_param( 'allDay' ) ) ) {
+			$meta['all_day'] = 1;
+		}
+
+		/**
+		 * Filter the appointment meta before it is persisted on create.
+		 *
+		 * Lets Pro addons attach their own meta (e.g. employee_id, location_id,
+		 * payment_status) to a new appointment without core knowing the keys.
+		 *
+		 * @param array           $meta    Meta key/value pairs to store.
+		 * @param WP_REST_Request $request The create request.
+		 */
+		$meta = apply_filters( 'wpappointments_appointment_meta', $meta, $request );
+
 		$appointment       = new Appointment(
 			array(
 				'title'    => $service,
@@ -251,6 +276,38 @@ class AppointmentsController extends Controller {
 				'appointment' => $saved_appointment->normalize( array( __CLASS__, 'normalize' ) ),
 			),
 		);
+	}
+
+	/**
+	 * Parse and validate an optional multi-day end timestamp from the request.
+	 *
+	 * When the booking spans multiple days the client sends `endDate`; the
+	 * resolved timestamp must be after the start. Returns null when no end date
+	 * was supplied (single-day appointment), or a WP_Error on invalid input.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @param int             $start   Start timestamp (unix).
+	 *
+	 * @return int|null|\WP_Error
+	 */
+	private static function parse_end_timestamp( WP_REST_Request $request, $start ) {
+		$end_date_raw = $request->get_param( 'endDate' );
+
+		if ( null === $end_date_raw ) {
+			return null;
+		}
+
+		$end_timestamp = rest_parse_date( get_gmt_from_date( sanitize_text_field( $end_date_raw ) ) );
+
+		if ( false === $end_timestamp ) {
+			return new \WP_Error( 'invalid_end_date', __( 'Invalid end date format', 'appstip-appointments' ), array( 'status' => 422 ) );
+		}
+
+		if ( $end_timestamp <= $start ) {
+			return new \WP_Error( 'invalid_end_date', __( 'End date must be after the start date', 'appstip-appointments' ), array( 'status' => 422 ) );
+		}
+
+		return $end_timestamp;
 	}
 
 	/**
@@ -300,6 +357,23 @@ class AppointmentsController extends Controller {
 		if ( $entity_id > 0 ) {
 			$meta['entity_id'] = $entity_id;
 		}
+
+		$end_timestamp = self::parse_end_timestamp( $request, $date );
+
+		if ( is_wp_error( $end_timestamp ) ) {
+			return self::error( $end_timestamp );
+		}
+
+		if ( null !== $end_timestamp ) {
+			$meta['end_timestamp'] = $end_timestamp;
+		}
+
+		if ( rest_sanitize_boolean( $request->get_param( 'allDay' ) ) ) {
+			$meta['all_day'] = 1;
+		}
+
+		/** This filter is documented in self::create_appointment(). */
+		$meta = apply_filters( 'wpappointments_appointment_meta', $meta, $request );
 
 		$appointment       = new Appointment(
 			array(
@@ -516,20 +590,27 @@ class AppointmentsController extends Controller {
 	public static function normalize( $appointment ) {
 		$length = (int) get_option( 'wpappointments_appointments_defaultLength' );
 
-		$timestamp   = get_post_meta( $appointment->ID, 'timestamp', true );
-		$status      = get_post_meta( $appointment->ID, 'status', true );
-		$duration    = get_post_meta( $appointment->ID, 'duration', true ) ?? $length;
-		$customer_id = get_post_meta( $appointment->ID, 'customer_id', true ) ?? 0;
-		$customer    = get_post_meta( $appointment->ID, 'customer', true ) ?? null;
+		$timestamp     = get_post_meta( $appointment->ID, 'timestamp', true );
+		$status        = get_post_meta( $appointment->ID, 'status', true );
+		$duration      = get_post_meta( $appointment->ID, 'duration', true ) ?? $length;
+		$customer_id   = get_post_meta( $appointment->ID, 'customer_id', true ) ?? 0;
+		$customer      = get_post_meta( $appointment->ID, 'customer', true ) ?? null;
+		$end_timestamp = get_post_meta( $appointment->ID, 'end_timestamp', true );
+
+		$end_timestamp = '' !== $end_timestamp
+		? (int) $end_timestamp
+		: (int) $timestamp + (int) $duration * 60;
 
 		return array(
-			'id'         => $appointment->ID,
-			'service'    => $appointment->post_title,
-			'status'     => $status,
-			'timestamp'  => (int) $timestamp,
-			'duration'   => (int) $duration,
-			'customerId' => (int) $customer_id,
-			'customer'   => maybe_unserialize( $customer ),
+			'id'           => $appointment->ID,
+			'service'      => $appointment->post_title,
+			'status'       => $status,
+			'timestamp'    => (int) $timestamp,
+			'endTimestamp' => $end_timestamp,
+			'allDay'       => (bool) get_post_meta( $appointment->ID, 'all_day', true ),
+			'duration'     => (int) $duration,
+			'customerId'   => (int) $customer_id,
+			'customer'     => maybe_unserialize( $customer ),
 		);
 	}
 }

--- a/plugins/appstip-appointments/src/Api/Endpoints/BookableAvailabilityController.php
+++ b/plugins/appstip-appointments/src/Api/Endpoints/BookableAvailabilityController.php
@@ -286,17 +286,39 @@ class BookableAvailabilityController extends Controller {
 		$appointment_periods = array();
 
 		foreach ( $appointments as $appointment ) {
+			$appt_start = (int) $appointment['timestamp'];
+			// Honour an explicit end timestamp (multi-day / all-day bookings);
+			// AppointmentsQuery falls back to start + duration for single-day.
+			$appt_end = isset( $appointment['endTimestamp'] )
+			? (int) $appointment['endTimestamp']
+			: $appt_start + (int) $appointment['duration'] * 60;
+
 			$start = new \DateTime();
-			$start->setTimestamp( $appointment['timestamp'] - $buffers['before'] * 60 );
+			$start->setTimestamp( $appt_start - $buffers['before'] * 60 );
 			$end = new \DateTime();
-			$end->setTimestamp( $appointment['timestamp'] + $appointment['duration'] * 60 + $buffers['after'] * 60 );
-			$total                 = $buffers['before'] + $appointment['duration'] + $buffers['after'];
+			$end->setTimestamp( $appt_end + $buffers['after'] * 60 );
+
+			$total_minutes         = max( 1, (int) round( ( $appt_end - $appt_start ) / 60 ) + $buffers['before'] + $buffers['after'] );
 			$appointment_periods[] = new \DatePeriod(
 				$start,
-				new \DateInterval( 'PT' . $total . 'M' ),
+				new \DateInterval( 'PT' . $total_minutes . 'M' ),
 				$end
 			);
 		}
+
+		/**
+		 * Filter the busy periods that block availability for this query.
+		 *
+		 * Pro addons (employees, locations) use this to add or replace the
+		 * conflict set with resource-scoped busy periods derived from the
+		 * availability context (e.g. employee_id, location_id), so booking a
+		 * specific employee only conflicts with that employee's appointments.
+		 *
+		 * @param \DatePeriod[] $appointment_periods Busy periods blocking slots.
+		 * @param array         $context             Availability context (employee_id, location_id, ...).
+		 * @param array         $date_range          Query date range (start/end Y-m-d).
+		 */
+		$appointment_periods = apply_filters( 'wpappointments_busy_periods', $appointment_periods, $context, $date_range );
 
 		// Generate slots for each day in the calendar.
 		$availability = array();

--- a/plugins/appstip-appointments/src/Data/Model/Appointment.php
+++ b/plugins/appstip-appointments/src/Data/Model/Appointment.php
@@ -280,20 +280,29 @@ class Appointment {
 	public static function default_normalizer( $appointment ) {
 		$length = (int) get_option( 'wpappointments_appointments_defaultLength' );
 
-		$timestamp   = get_post_meta( $appointment->ID, 'timestamp', true );
-		$status      = get_post_meta( $appointment->ID, 'status', true );
-		$duration    = get_post_meta( $appointment->ID, 'duration', true ) ?? $length;
-		$customer_id = get_post_meta( $appointment->ID, 'customer_id', true ) ?? 0;
-		$customer    = get_post_meta( $appointment->ID, 'customer', true ) ?? null;
+		$timestamp     = get_post_meta( $appointment->ID, 'timestamp', true );
+		$status        = get_post_meta( $appointment->ID, 'status', true );
+		$duration      = get_post_meta( $appointment->ID, 'duration', true ) ?? $length;
+		$customer_id   = get_post_meta( $appointment->ID, 'customer_id', true ) ?? 0;
+		$customer      = get_post_meta( $appointment->ID, 'customer', true ) ?? null;
+		$end_timestamp = get_post_meta( $appointment->ID, 'end_timestamp', true );
+
+		// Single-day appointments store no end_timestamp; fall back to
+		// start + duration so multi-day and single-day read uniformly.
+		$end_timestamp = '' !== $end_timestamp
+		? (int) $end_timestamp
+		: (int) $timestamp + (int) $duration * 60;
 
 		return array(
-			'id'          => $appointment->ID,
-			'service'     => $appointment->post_title,
-			'status'      => $status,
-			'timestamp'   => (int) $timestamp,
-			'duration'    => (int) $duration,
-			'customer_id' => (int) $customer_id,
-			'customer'    => maybe_unserialize( $customer ),
+			'id'            => $appointment->ID,
+			'service'       => $appointment->post_title,
+			'status'        => $status,
+			'timestamp'     => (int) $timestamp,
+			'end_timestamp' => $end_timestamp,
+			'all_day'       => (bool) get_post_meta( $appointment->ID, 'all_day', true ),
+			'duration'      => (int) $duration,
+			'customer_id'   => (int) $customer_id,
+			'customer'      => maybe_unserialize( $customer ),
 		);
 	}
 

--- a/plugins/appstip-appointments/src/Data/Query/AppointmentsQuery.php
+++ b/plugins/appstip-appointments/src/Data/Query/AppointmentsQuery.php
@@ -234,9 +234,11 @@ class AppointmentsQuery {
 			$appointments[] = self::normalize(
 				$post->ID,
 				array(
-					'status'    => $meta['status'][0],
-					'timestamp' => $meta['timestamp'][0],
-					'duration'  => $meta['duration'][0],
+					'status'        => $meta['status'][0],
+					'timestamp'     => $meta['timestamp'][0],
+					'duration'      => $meta['duration'][0],
+					'end_timestamp' => $meta['end_timestamp'][0] ?? '',
+					'all_day'       => $meta['all_day'][0] ?? '',
 				)
 			);
 		}
@@ -265,14 +267,24 @@ class AppointmentsQuery {
 			$customer = maybe_unserialize( $customer );
 		}
 
+		// End timestamp falls back to start + duration when not explicitly
+		// stored (every legacy appointment), so consumers can treat single-day
+		// and multi-day / all-day appointments uniformly.
+		$end_meta      = $meta['end_timestamp'] ?? '';
+		$end_timestamp = '' !== $end_meta && null !== $end_meta
+		? (int) $end_meta
+		: (int) $timestamp + (int) $duration * 60;
+
 		return array(
-			'id'         => $post_id,
-			'service'    => get_the_title( $post_id ),
-			'timestamp'  => (int) $timestamp,
-			'status'     => $status,
-			'duration'   => (int) $duration,
-			'customerId' => (int) $customer_id,
-			'customer'   => $customer,
+			'id'           => $post_id,
+			'service'      => get_the_title( $post_id ),
+			'timestamp'    => (int) $timestamp,
+			'endTimestamp' => $end_timestamp,
+			'allDay'       => ! empty( $meta['all_day'] ),
+			'status'       => $status,
+			'duration'     => (int) $duration,
+			'customerId'   => (int) $customer_id,
+			'customer'     => $customer,
 		);
 	}
 

--- a/plugins/appstip-appointments/tests/php/Api/Endpoints/AppointmentsControllerTest.php
+++ b/plugins/appstip-appointments/tests/php/Api/Endpoints/AppointmentsControllerTest.php
@@ -779,3 +779,100 @@ test(
 		expect( $results )->toBeError( 422, 'appointment_not_found' );
 	}
 );
+
+test(
+	'POST appointments - wpappointments_appointment_meta filter can inject meta',
+	function () {
+		wp_set_current_user( 1 );
+
+		$filter = function ( $meta ) {
+			$meta['employee_id'] = 42;
+			return $meta;
+		};
+		add_filter( 'wpappointments_appointment_meta', $filter );
+
+		$results = $this->do_rest_post_request(
+			'appointments',
+			array(
+				'date'       => time() + 3600,
+				'service'    => 'Service 1',
+				'duration'   => 60,
+				'customer'   => array(
+					'name'  => 'John Doe',
+					'email' => 'john@example.com',
+					'phone' => '+1 (000) 000-0000',
+				),
+				'customerId' => 1,
+				'status'     => 'confirmed',
+			)
+		);
+
+		remove_filter( 'wpappointments_appointment_meta', $filter );
+
+		$id = $results->get_data()['data']['appointment']['id'];
+
+		expect( (int) get_post_meta( $id, 'employee_id', true ) )->toBe( 42 );
+	}
+);
+
+test(
+	'POST appointments - endDate and allDay are persisted and normalized',
+	function () {
+		wp_set_current_user( 1 );
+
+		$start_ts = time() + 3600;
+		$end_ts   = $start_ts + 2 * DAY_IN_SECONDS;
+
+		$results = $this->do_rest_post_request(
+			'appointments',
+			array(
+				'date'       => gmdate( 'Y-m-d H:i:s', $start_ts ),
+				'endDate'    => gmdate( 'Y-m-d H:i:s', $end_ts ),
+				'allDay'     => true,
+				'service'    => 'Multi day',
+				'duration'   => 60,
+				'customer'   => array(
+					'name'  => 'John Doe',
+					'email' => 'john@example.com',
+					'phone' => '+1 (000) 000-0000',
+				),
+				'customerId' => 1,
+				'status'     => 'confirmed',
+			)
+		);
+
+		$appt = $results->get_data()['data']['appointment'];
+
+		expect( $appt['allDay'] )->toBeTrue();
+		expect( $appt['endTimestamp'] )->toBeGreaterThan( $appt['timestamp'] );
+	}
+);
+
+test(
+	'POST appointments - endDate before start is rejected',
+	function () {
+		wp_set_current_user( 1 );
+
+		$start_ts = time() + 3 * DAY_IN_SECONDS;
+		$end_ts   = $start_ts - DAY_IN_SECONDS;
+
+		$results = $this->do_rest_post_request(
+			'appointments',
+			array(
+				'date'       => gmdate( 'Y-m-d H:i:s', $start_ts ),
+				'endDate'    => gmdate( 'Y-m-d H:i:s', $end_ts ),
+				'service'    => 'Bad range',
+				'duration'   => 60,
+				'customer'   => array(
+					'name'  => 'John Doe',
+					'email' => 'john@example.com',
+					'phone' => '+1 (000) 000-0000',
+				),
+				'customerId' => 1,
+				'status'     => 'confirmed',
+			)
+		);
+
+		expect( $results )->toBeError( 422, 'invalid_end_date' );
+	}
+);

--- a/plugins/appstip-appointments/tests/php/Api/Endpoints/BookableAvailabilityControllerTest.php
+++ b/plugins/appstip-appointments/tests/php/Api/Endpoints/BookableAvailabilityControllerTest.php
@@ -137,3 +137,71 @@ test(
 		expect( $captured->context['custom_key'] )->toBe( 'abc' );
 	}
 );
+
+test(
+	'calendar-slots passes context to the wpappointments_busy_periods filter',
+	function () {
+		$variant_id = create_availability_variant();
+		$entity_id  = get_post( $variant_id )->post_parent;
+
+		$captured = new \stdClass();
+
+		$filter = function ( $periods, $context ) use ( $captured ) {
+			$captured->context = $context;
+			return $periods;
+		};
+		add_filter( 'wpappointments_busy_periods', $filter, 10, 2 );
+
+		$this->do_rest_get_request(
+			"bookables/{$entity_id}/calendar-slots",
+			array(
+				'calendar'   => wp_json_encode( array( array( '2026-06-01' ) ) ),
+				'timezone'   => 'UTC',
+				'employeeId' => 5,
+			)
+		);
+
+		remove_filter( 'wpappointments_busy_periods', $filter, 10 );
+
+		expect( $captured->context['employee_id'] )->toBe( 5 );
+	}
+);
+
+test(
+	'wpappointments_busy_periods filter can block an otherwise-open slot',
+	function () {
+		$variant_id = create_availability_variant();
+		$entity_id  = get_post( $variant_id )->post_parent;
+
+		// Block the whole of 2026-06-01 via an injected busy period.
+		$filter = function ( $periods ) {
+			$start     = new \DateTime( '2026-06-01 00:00:00', new \DateTimeZone( 'UTC' ) );
+			$end       = new \DateTime( '2026-06-02 00:00:00', new \DateTimeZone( 'UTC' ) );
+			$periods[] = new \DatePeriod( $start, new \DateInterval( 'PT1440M' ), $end );
+			return $periods;
+		};
+		add_filter( 'wpappointments_busy_periods', $filter );
+
+		$response = $this->do_rest_get_request(
+			"bookables/{$entity_id}/calendar-slots",
+			array(
+				'calendar' => wp_json_encode( array( array( '2026-06-01' ) ) ),
+				'timezone' => 'UTC',
+			)
+		);
+
+		remove_filter( 'wpappointments_busy_periods', $filter );
+
+		$data  = $response->get_data();
+		$slots = $data['data']['availability'][0][0]['day'];
+
+		// Every slot that day overlaps the injected busy period -> not available.
+		$available = array_filter(
+			$slots,
+			function ( $s ) {
+				return true === $s['available'];
+			}
+		);
+		expect( $available )->toBeEmpty();
+	}
+);

--- a/plugins/appstip-appointments/tests/php/Data/Model/AppointmentTest.php
+++ b/plugins/appstip-appointments/tests/php/Data/Model/AppointmentTest.php
@@ -734,3 +734,52 @@ test(
 		expect( get_option( 'wpappointments_appointment_deleted_hook_fired' ) )->toBeFalse();
 	}
 );
+
+// End timestamp / all-day normalization (CORE-A multi-day support).
+test(
+	'Appointment model - default_normalizer falls back end_timestamp to start + duration',
+	function () {
+		$id = wp_insert_post(
+			array(
+				'post_title'  => 'Single day',
+				'post_status' => 'publish',
+				'post_type'   => 'wpa-appointment',
+				'meta_input'  => array(
+					'timestamp' => 1000000,
+					'duration'  => 60,
+					'status'    => 'confirmed',
+				),
+			)
+		);
+
+		$normalized = ( new Appointment( $id ) )->normalize();
+
+		expect( $normalized['end_timestamp'] )->toBe( 1000000 + 60 * 60 );
+		expect( $normalized['all_day'] )->toBeFalse();
+	}
+);
+
+test(
+	'Appointment model - default_normalizer honours explicit end_timestamp and all_day',
+	function () {
+		$id = wp_insert_post(
+			array(
+				'post_title'  => 'Multi day',
+				'post_status' => 'publish',
+				'post_type'   => 'wpa-appointment',
+				'meta_input'  => array(
+					'timestamp'     => 1000000,
+					'duration'      => 60,
+					'status'        => 'confirmed',
+					'end_timestamp' => 1300000,
+					'all_day'       => 1,
+				),
+			)
+		);
+
+		$normalized = ( new Appointment( $id ) )->normalize();
+
+		expect( $normalized['end_timestamp'] )->toBe( 1300000 );
+		expect( $normalized['all_day'] )->toBeTrue();
+	}
+);

--- a/plugins/appstip-appointments/tests/php/Data/Query/AppointmentsQueryTest.php
+++ b/plugins/appstip-appointments/tests/php/Data/Query/AppointmentsQueryTest.php
@@ -120,3 +120,51 @@ test(
 		expect( $only_999['appointments'] )->toHaveCount( 1 );
 	}
 );
+
+test(
+	'AppointmentsQuery::get_date_range_appointments exposes end_timestamp (explicit + fallback)',
+	function () {
+		$start = 2000000000;
+
+		$single = wp_insert_post(
+			array(
+				'post_type'   => 'wpa-appointment',
+				'post_status' => 'publish',
+				'post_title'  => 'single',
+				'meta_input'  => array(
+					'status'    => 'confirmed',
+					'timestamp' => $start,
+					'duration'  => 30,
+				),
+			)
+		);
+
+		$multi_start = $start + 100;
+		$multi       = wp_insert_post(
+			array(
+				'post_type'   => 'wpa-appointment',
+				'post_status' => 'publish',
+				'post_title'  => 'multi',
+				'meta_input'  => array(
+					'status'        => 'confirmed',
+					'timestamp'     => $multi_start,
+					'duration'      => 30,
+					'end_timestamp' => $multi_start + 3 * DAY_IN_SECONDS,
+				),
+			)
+		);
+
+		$results = AppointmentsQuery::get_date_range_appointments( $start - 10, $start + 200 );
+
+		$by_id = array();
+		foreach ( $results['appointments'] as $appointment ) {
+			$by_id[ $appointment['id'] ] = $appointment;
+		}
+
+		// Single-day falls back to start + duration*60.
+		expect( $by_id[ $single ]['endTimestamp'] )->toBe( $start + 30 * 60 );
+		// Multi-day honours the stored end_timestamp.
+		expect( $by_id[ $multi ]['endTimestamp'] )->toBe( $multi_start + 3 * DAY_IN_SECONDS );
+		expect( $by_id[ $multi ]['allDay'] )->toBeFalse();
+	}
+);


### PR DESCRIPTION
## What

Adds the additive core seams the next-wave Pro addons need for **multi-day / all-day bookings** and **per-resource conflict resolution**. No behaviour change when no addon is active — every new field falls back to the existing single-day math.

## Changes

- **Time model**: `end_timestamp` + `all_day` appointment meta. Both normalizers (`Data\Model\Appointment`, `AppointmentsController`) and `AppointmentsQuery` emit them, with `end_timestamp` falling back to `timestamp + duration*60` so every legacy appointment reads uniformly.
- **Conflict math** (`BookableAvailabilityController`) honours `end_timestamp`, so a multi-day appointment blocks its whole span.
- **`wpappointments_busy_periods( $periods, $context, $range )`** filter: addons add/replace the conflict set with resource-scoped busy periods (employee/location) using the availability context. This is what makes "booking a specific employee only conflicts with that employee" possible.
- **`wpappointments_appointment_meta( $meta, $request )`** filter: addons attach their own meta (`employee_id`, `location_id`, `payment_status`, …) on create without core knowing the keys. Wired into both the authenticated and public create endpoints, which now also accept `endDate` + `allDay`.

## Tests

Normalizer fallback/explicit, `AppointmentsQuery` end_timestamp passthrough, `busy_periods` context + slot blocking, `appointment_meta` injection, `endDate`/`allDay` persistence and invalid-range rejection. Full Pest suite green (282).

## Notes

- **Recurrence** (RRULE meta + expander, the `rrule`/`recurrence_exceptions` half of the original CORE-A scope) is a self-contained follow-up (CORE-A2) — kept out to keep this reviewable.
- Stacked on `feat/availability-context-passthrough` (CORE-B, #459) because both touch `BookableAvailabilityController`. Retarget to `main` once #458/#459 merge.
- Known limitation (documented): the date-range query still selects appointments by *start* timestamp, so a multi-day appointment whose start precedes the viewed window relies on the `busy_periods` filter for precise overlap. Addons doing resource-scoped conflicts query overlap directly.