### PR TITLE
feat(appointments): RRULE recurrence engine (CORE-A2)

### DIFF
--- a/plugins/appstip-appointments/composer.json
+++ b/plugins/appstip-appointments/composer.json
@@ -1,6 +1,9 @@
 {
 	"name": "wpappointments/wpappointments",
 	"type": "wordpress-plugin",
+	"require": {
+		"rlanvin/php-rrule": "^2.5"
+	},
 	"autoload": {
 		"psr-4": {
 			"WPAppointments\\": "src/",

--- a/plugins/appstip-appointments/composer.lock
+++ b/plugins/appstip-appointments/composer.lock
@@ -4,8 +4,58 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "16f1d9c7caea0b8759c69d370f71b07a",
-    "packages": [],
+    "content-hash": "131f91622ac1c9cc561e8b04875ae540",
+    "packages": [
+        {
+            "name": "rlanvin/php-rrule",
+            "version": "v2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rlanvin/php-rrule.git",
+                "reference": "2a389a9fa67dda58bc5a569a3264555152db3c49"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rlanvin/php-rrule/zipball/2a389a9fa67dda58bc5a569a3264555152db3c49",
+                "reference": "2a389a9fa67dda58bc5a569a3264555152db3c49",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpmd/phpmd": "@stable",
+                "phpunit/phpunit": "^5.7|^6.5|^8.0"
+            },
+            "suggest": {
+                "ext-intl": "Intl extension is needed for humanReadable()"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "RRule\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Lightweight and fast recurrence rules for PHP (RFC 5545)",
+            "homepage": "https://github.com/rlanvin/php-rrule",
+            "keywords": [
+                "date",
+                "ical",
+                "recurrence",
+                "recurring",
+                "rrule"
+            ],
+            "support": {
+                "issues": "https://github.com/rlanvin/php-rrule/issues",
+                "source": "https://github.com/rlanvin/php-rrule/tree/v2.6.0"
+            },
+            "time": "2025-04-25T07:40:09+00:00"
+        }
+    ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
@@ -14,5 +64,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/plugins/appstip-appointments/src/Api/Endpoints/AppointmentsController.php
+++ b/plugins/appstip-appointments/src/Api/Endpoints/AppointmentsController.php
@@ -18,11 +18,20 @@ use WPAppointments\Data\Query\AppointmentsQuery;
 use WP_Query;
 use WP_REST_Controller;
 use WPAppointments\Core\Capabilities;
+use WPAppointments\Recurrence\RecurrenceExpander;
+use RRule\RRule;
 
 /**
  * Appointment endpoint class
  */
 class AppointmentsController extends Controller {
+	/**
+	 * Maximum number of recurrence exceptions (EXDATEs) accepted per appointment.
+	 *
+	 * @var int
+	 */
+	const MAX_RECURRENCE_EXCEPTIONS = 1000;
+
 	/**
 	 * Register all routes
 	 *
@@ -250,6 +259,14 @@ class AppointmentsController extends Controller {
 			$meta['all_day'] = 1;
 		}
 
+		$recurrence = self::parse_recurrence( $request );
+
+		if ( is_wp_error( $recurrence ) ) {
+			return self::error( $recurrence );
+		}
+
+		$meta = array_merge( $meta, $recurrence );
+
 		/**
 		 * Filter the appointment meta before it is persisted on create.
 		 *
@@ -308,6 +325,61 @@ class AppointmentsController extends Controller {
 		}
 
 		return $end_timestamp;
+	}
+
+	/**
+	 * Parse and validate optional recurrence meta from the request.
+	 *
+	 * Returns the meta to merge: `rrule` (validated RRULE string) when the
+	 * request carries a non-empty `rrule`, and `recurrence_exceptions` (array
+	 * of unix timestamps) when `recurrenceExceptions` is supplied. When no
+	 * rrule is present the result is empty and the appointment behaves exactly
+	 * as a non-recurring one.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return array|\WP_Error
+	 */
+	private static function parse_recurrence( WP_REST_Request $request ) {
+		$rrule_raw = $request->get_param( 'rrule' );
+
+		if ( null === $rrule_raw || '' === trim( (string) $rrule_raw ) ) {
+			return array();
+		}
+
+		$rrule = sanitize_text_field( $rrule_raw );
+
+		// Reject sub-daily frequencies: appointments never recur by the
+		// second/minute, and such rules expand into huge occurrence sets that
+		// would exhaust CPU/memory on every calendar read.
+		if ( preg_match( '/FREQ\s*=\s*(SECONDLY|MINUTELY)/i', $rrule ) ) {
+			return new \WP_Error( 'invalid_rrule', __( 'Recurrence frequency is not allowed', 'appstip-appointments' ), array( 'status' => 422 ) );
+		}
+
+		// php-rrule has no validator; constructing throws on a malformed rule.
+		try {
+			new RRule( $rrule );
+		} catch ( \InvalidArgumentException $e ) {
+			return new \WP_Error( 'invalid_rrule', __( 'Invalid recurrence rule', 'appstip-appointments' ), array( 'status' => 422 ) );
+		}
+
+		$meta = array(
+			'rrule' => $rrule,
+		);
+
+		$exceptions_raw = $request->get_param( 'recurrenceExceptions' );
+
+		if ( is_array( $exceptions_raw ) ) {
+			// Bound the exception set so a single appointment cannot carry an
+			// unbounded list that turns expansion into an O(n^2) scan.
+			if ( count( $exceptions_raw ) > self::MAX_RECURRENCE_EXCEPTIONS ) {
+				return new \WP_Error( 'too_many_exceptions', __( 'Too many recurrence exceptions', 'appstip-appointments' ), array( 'status' => 422 ) );
+			}
+
+			$meta['recurrence_exceptions'] = array_values( array_map( 'absint', $exceptions_raw ) );
+		}
+
+		return $meta;
 	}
 
 	/**
@@ -371,6 +443,14 @@ class AppointmentsController extends Controller {
 		if ( rest_sanitize_boolean( $request->get_param( 'allDay' ) ) ) {
 			$meta['all_day'] = 1;
 		}
+
+		$recurrence = self::parse_recurrence( $request );
+
+		if ( is_wp_error( $recurrence ) ) {
+			return self::error( $recurrence );
+		}
+
+		$meta = array_merge( $meta, $recurrence );
 
 		/** This filter is documented in self::create_appointment(). */
 		$meta = apply_filters( 'wpappointments_appointment_meta', $meta, $request );
@@ -601,16 +681,23 @@ class AppointmentsController extends Controller {
 		? (int) $end_timestamp
 		: (int) $timestamp + (int) $duration * 60;
 
+		$rrule                 = get_post_meta( $appointment->ID, 'rrule', true );
+		$recurrence_exceptions = get_post_meta( $appointment->ID, 'recurrence_exceptions', true );
+		$recurrence_parent     = get_post_meta( $appointment->ID, 'recurrence_parent', true );
+
 		return array(
-			'id'           => $appointment->ID,
-			'service'      => $appointment->post_title,
-			'status'       => $status,
-			'timestamp'    => (int) $timestamp,
-			'endTimestamp' => $end_timestamp,
-			'allDay'       => (bool) get_post_meta( $appointment->ID, 'all_day', true ),
-			'duration'     => (int) $duration,
-			'customerId'   => (int) $customer_id,
-			'customer'     => maybe_unserialize( $customer ),
+			'id'                   => $appointment->ID,
+			'service'              => $appointment->post_title,
+			'status'               => $status,
+			'timestamp'            => (int) $timestamp,
+			'endTimestamp'         => $end_timestamp,
+			'allDay'               => (bool) get_post_meta( $appointment->ID, 'all_day', true ),
+			'duration'             => (int) $duration,
+			'customerId'           => (int) $customer_id,
+			'customer'             => maybe_unserialize( $customer ),
+			'rrule'                => is_string( $rrule ) ? $rrule : '',
+			'recurrenceExceptions' => is_array( $recurrence_exceptions ) ? array_map( 'intval', $recurrence_exceptions ) : array(),
+			'recurrenceParent'     => $recurrence_parent ? (int) $recurrence_parent : 0,
 		);
 	}
 }

--- a/plugins/appstip-appointments/src/Data/Model/Appointment.php
+++ b/plugins/appstip-appointments/src/Data/Model/Appointment.php
@@ -169,6 +169,114 @@ class Appointment {
 	}
 
 	/**
+	 * Detach a single occurrence from a recurring master.
+	 *
+	 * Edit-single semantics: materialise the given occurrence as a standalone
+	 * (non-recurring) child appointment that carries `recurrence_parent` and
+	 * `post_parent` pointing at the master, then EXDATE the master at the
+	 * original occurrence timestamp so the series no longer expands it.
+	 *
+	 * The child inherits the master's meta minus the recurrence keys, with its
+	 * own start (and matching end preserving the master's duration). Callers may
+	 * pass `$overrides` to change child meta (e.g. status, duration) and
+	 * `$new_timestamp` to also move the occurrence.
+	 *
+	 * @param int      $occurrence_timestamp Original occurrence start (unix UTC) to detach.
+	 * @param array    $overrides            Optional child meta overrides.
+	 * @param int|null $new_timestamp        Optional new start for the child (unix UTC).
+	 *
+	 * @return Appointment|\WP_Error The detached child appointment, or error.
+	 */
+	public function detach_occurrence( $occurrence_timestamp, $overrides = array(), $new_timestamp = null ) {
+		if ( is_wp_error( $this->appointment ) ) {
+			return $this->appointment;
+		}
+
+		$master_id    = $this->appointment->ID;
+		$master_rrule = get_post_meta( $master_id, 'rrule', true );
+
+		if ( '' === $master_rrule || null === $master_rrule ) {
+			return new \WP_Error(
+				'appointment_not_recurring',
+				__( 'Appointment is not recurring', 'appstip-appointments' )
+			);
+		}
+
+		$occurrence_timestamp = (int) $occurrence_timestamp;
+
+		// Idempotency guard: an already-EXDATEd occurrence has already been
+		// detached. Creating a second child would duplicate the appointment and
+		// break the dedup invariant, so refuse.
+		$existing_exceptions = get_post_meta( $master_id, 'recurrence_exceptions', true );
+		$existing_exceptions = is_array( $existing_exceptions ) ? array_map( 'intval', $existing_exceptions ) : array();
+
+		if ( in_array( $occurrence_timestamp, $existing_exceptions, true ) ) {
+			return new \WP_Error(
+				'occurrence_already_detached',
+				__( 'This occurrence has already been detached', 'appstip-appointments' )
+			);
+		}
+
+		$master_start = (int) get_post_meta( $master_id, 'timestamp', true );
+		$master_dur   = (int) get_post_meta( $master_id, 'duration', true );
+		$master_end   = get_post_meta( $master_id, 'end_timestamp', true );
+		$duration_sec = '' !== $master_end && null !== $master_end
+		? (int) $master_end - $master_start
+		: $master_dur * 60;
+
+		$child_start = null !== $new_timestamp ? (int) $new_timestamp : $occurrence_timestamp;
+
+		// Inherit master meta, dropping the recurrence-defining keys so the
+		// child is a plain one-off appointment.
+		$inherited  = get_post_meta( $master_id );
+		$child_meta = array();
+
+		foreach ( $inherited as $key => $values ) {
+			if ( in_array( $key, array( 'rrule', 'recurrence_exceptions', 'recurrence_parent' ), true ) ) {
+				continue;
+			}
+
+			$child_meta[ $key ] = maybe_unserialize( $values[0] );
+		}
+
+		$child_meta['timestamp']         = $child_start;
+		$child_meta['end_timestamp']     = $child_start + $duration_sec;
+		$child_meta['recurrence_parent'] = $master_id;
+
+		$child_meta = wp_parse_args( $overrides, $child_meta );
+
+		$child_id = wp_insert_post(
+			array(
+				'post_type'   => 'wpa-appointment',
+				'post_status' => 'publish',
+				'post_title'  => $this->appointment->post_title,
+				'post_parent' => $master_id,
+				'meta_input'  => $child_meta,
+			),
+			true
+		);
+
+		if ( is_wp_error( $child_id ) ) {
+			return $child_id;
+		}
+
+		// EXDATE the master so the series stops expanding the original slot.
+		$exceptions = get_post_meta( $master_id, 'recurrence_exceptions', true );
+		$exceptions = is_array( $exceptions ) ? $exceptions : array();
+
+		if ( ! in_array( $occurrence_timestamp, array_map( 'intval', $exceptions ), true ) ) {
+			$exceptions[] = $occurrence_timestamp;
+			update_post_meta( $master_id, 'recurrence_exceptions', $exceptions );
+		}
+
+		$child = new self( get_post( $child_id ) );
+
+		do_action( 'wpappointments_appointment_occurrence_detached', $child->normalize(), $master_id, $occurrence_timestamp );
+
+		return $child;
+	}
+
+	/**
 	 * Cancel appointment
 	 *
 	 * @return array|\WP_Error
@@ -293,16 +401,23 @@ class Appointment {
 		? (int) $end_timestamp
 		: (int) $timestamp + (int) $duration * 60;
 
+		$rrule                 = get_post_meta( $appointment->ID, 'rrule', true );
+		$recurrence_exceptions = get_post_meta( $appointment->ID, 'recurrence_exceptions', true );
+		$recurrence_parent     = get_post_meta( $appointment->ID, 'recurrence_parent', true );
+
 		return array(
-			'id'            => $appointment->ID,
-			'service'       => $appointment->post_title,
-			'status'        => $status,
-			'timestamp'     => (int) $timestamp,
-			'end_timestamp' => $end_timestamp,
-			'all_day'       => (bool) get_post_meta( $appointment->ID, 'all_day', true ),
-			'duration'      => (int) $duration,
-			'customer_id'   => (int) $customer_id,
-			'customer'      => maybe_unserialize( $customer ),
+			'id'                    => $appointment->ID,
+			'service'               => $appointment->post_title,
+			'status'                => $status,
+			'timestamp'             => (int) $timestamp,
+			'end_timestamp'         => $end_timestamp,
+			'all_day'               => (bool) get_post_meta( $appointment->ID, 'all_day', true ),
+			'duration'              => (int) $duration,
+			'customer_id'           => (int) $customer_id,
+			'customer'              => maybe_unserialize( $customer ),
+			'rrule'                 => is_string( $rrule ) ? $rrule : '',
+			'recurrence_exceptions' => is_array( $recurrence_exceptions ) ? array_map( 'intval', $recurrence_exceptions ) : array(),
+			'recurrence_parent'     => $recurrence_parent ? (int) $recurrence_parent : 0,
 		);
 	}
 

--- a/plugins/appstip-appointments/src/Data/Query/AppointmentsQuery.php
+++ b/plugins/appstip-appointments/src/Data/Query/AppointmentsQuery.php
@@ -9,6 +9,7 @@
 namespace WPAppointments\Data\Query;
 
 use WP_Query;
+use WPAppointments\Recurrence\RecurrenceExpander;
 
 /**
  * Appointments query class
@@ -197,6 +198,12 @@ class AppointmentsQuery {
 				'value'   => $end_date,
 				'compare' => '<=',
 			),
+			// Recurring masters are expanded separately so their first
+			// occurrence is not also returned as a raw single appointment.
+			array(
+				'key'     => 'rrule',
+				'compare' => 'NOT EXISTS',
+			),
 		);
 
 		if ( $entity_id > 0 ) {
@@ -243,7 +250,121 @@ class AppointmentsQuery {
 			);
 		}
 
-		return self::paginated( $query, $appointments );
+		$appointments = array_merge(
+			$appointments,
+			self::expand_recurring_in_range( $start_date, $end_date, $entity_id )
+		);
+
+		// This method returns the full date-range set (posts_per_page = -1), so
+		// the item total must include expanded occurrences, not just the raw
+		// posts WP_Query counted.
+		return self::paginated( $query, $appointments, count( $appointments ) );
+	}
+
+	/**
+	 * Expand recurring masters into virtual occurrences overlapping a range.
+	 *
+	 * Masters store an RRULE plus EXDATE timestamps; their `timestamp` (DTSTART)
+	 * may sit before the requested range yet still produce occurrences inside
+	 * it, so they are queried independently of the date-range filter and
+	 * expanded via RecurrenceExpander. Each occurrence is returned as a
+	 * normalized appointment row sharing the master's id/service/customer, with
+	 * its own start/end timestamps. Returns an empty array when no masters
+	 * exist, keeping non-recurring installs free of any extra work.
+	 *
+	 * @param int $start_date Range start (unix UTC).
+	 * @param int $end_date   Range end (unix UTC).
+	 * @param int $entity_id  Optional bookable entity scope.
+	 *
+	 * @return array
+	 */
+	protected static function expand_recurring_in_range( $start_date, $end_date, $entity_id = 0 ) {
+		$meta_query = array(
+			'relation' => 'AND',
+			array(
+				'key'     => 'rrule',
+				'compare' => 'EXISTS',
+			),
+		);
+
+		if ( $entity_id > 0 ) {
+			$meta_query[] = array(
+				'relation' => 'OR',
+				array(
+					'key'     => 'entity_id',
+					'value'   => $entity_id,
+					'compare' => '=',
+				),
+				array(
+					'key'     => 'entity_id',
+					'compare' => 'NOT EXISTS',
+				),
+			);
+		}
+
+		$query = new \WP_Query(
+			array_merge(
+				self::DEFAULT_QUERY_PART,
+				array(
+					'posts_per_page' => - 1,
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Bounded to recurring masters; expanded in-memory for the requested range.
+					'meta_query'     => $meta_query,
+				)
+			)
+		);
+
+		if ( empty( $query->posts ) ) {
+			return array();
+		}
+
+		$timezone = wp_timezone();
+
+		$occurrences = array();
+
+		foreach ( $query->posts as $post ) {
+			$meta  = get_post_meta( $post->ID );
+			$rrule = $meta['rrule'][0] ?? '';
+
+			if ( '' === $rrule ) {
+				continue;
+			}
+
+			$master_start = (int) ( $meta['timestamp'][0] ?? 0 );
+			$duration     = (int) ( $meta['duration'][0] ?? 0 );
+			$master_end   = isset( $meta['end_timestamp'][0] ) && '' !== $meta['end_timestamp'][0]
+			? (int) $meta['end_timestamp'][0]
+			: $master_start + $duration * 60;
+
+			$exceptions = isset( $meta['recurrence_exceptions'][0] )
+			? maybe_unserialize( $meta['recurrence_exceptions'][0] )
+			: array();
+			$exceptions = is_array( $exceptions ) ? $exceptions : array();
+
+			$expanded = RecurrenceExpander::expand_in_range(
+				$rrule,
+				$master_start,
+				$master_end,
+				(int) $start_date,
+				(int) $end_date,
+				$exceptions,
+				$timezone
+			);
+
+			foreach ( $expanded as $occurrence ) {
+				$occurrences[] = self::normalize(
+					$post->ID,
+					array(
+						'status'        => $meta['status'][0] ?? '',
+						'timestamp'     => $occurrence['start'],
+						'duration'      => $duration,
+						'end_timestamp' => $occurrence['end'],
+						'all_day'       => $meta['all_day'][0] ?? '',
+					)
+				);
+			}
+		}
+
+		return $occurrences;
 	}
 
 	/**
@@ -293,14 +414,18 @@ class AppointmentsQuery {
 	 *
 	 * @param WP_User_Query $query Query params.
 	 * @param array         $appointments Appointments array.
+	 * @param int|null      $total_override Explicit total item count. Use when
+	 *                                      $appointments includes rows not counted
+	 *                                      by the WP_Query (e.g. expanded recurring
+	 *                                      occurrences). Defaults to found_posts.
 	 *
 	 * @return object
 	 */
-	public static function paginated( $query, $appointments = array() ) {
+	public static function paginated( $query, $appointments = array(), $total_override = null ) {
 		$posts_per_page = (int) $query->get( 'posts_per_page' ) ?? 10;
 		$paged          = (int) $query->get( 'paged' ) ?? 1;
-		$total          = $query->found_posts;
-		$pages          = (int) ceil( $total / $posts_per_page );
+		$total          = null === $total_override ? $query->found_posts : (int) $total_override;
+		$pages          = $posts_per_page > 0 ? (int) ceil( $total / $posts_per_page ) : 1;
 
 		return array(
 			'appointments'   => $appointments,

--- a/plugins/appstip-appointments/src/Recurrence/RecurrenceExpander.php
+++ b/plugins/appstip-appointments/src/Recurrence/RecurrenceExpander.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Recurrence expander
+ *
+ * Expands a master appointment's RRULE into concrete occurrences on read.
+ * Core owns this so both recurring bookings and (future) schedule recurrence
+ * can reuse the exact same expansion semantics.
+ *
+ * @package WPAppointments
+ * @since 0.0.1
+ */
+
+namespace WPAppointments\Recurrence;
+
+use DateTime;
+use DateTimeZone;
+use RRule\RRule;
+
+/**
+ * Expand RRULE strings into occurrence timestamps.
+ *
+ * Timestamps are unix ints in UTC, matching the `timestamp` / `end_timestamp`
+ * meta convention. Expansion is performed in a wall-clock timezone so that a
+ * weekly/daily/monthly rule keeps the same local time across DST transitions;
+ * the resulting occurrences are converted back to unix UTC ints.
+ */
+class RecurrenceExpander {
+	/**
+	 * Hard cap on occurrences returned from a single expansion.
+	 *
+	 * A safety net against pathological rules (e.g. a wide range crossed with a
+	 * high-frequency RRULE). Expansion stops once this many occurrences are
+	 * collected, bounding CPU/memory regardless of the rule or range.
+	 *
+	 * @var int
+	 */
+	const MAX_OCCURRENCES = 1000;
+
+	/**
+	 * Whether an appointment is recurring.
+	 *
+	 * @param string|null $rrule Stored RRULE string (may be empty/null).
+	 *
+	 * @return bool
+	 */
+	public static function is_recurring( $rrule ) {
+		return is_string( $rrule ) && '' !== trim( $rrule );
+	}
+
+	/**
+	 * Expand a master RRULE into occurrences overlapping a range.
+	 *
+	 * Each occurrence preserves the master's duration
+	 * (occ_end = occ_start + (master_end - master_start)). Occurrences whose
+	 * start matches an EXDATE timestamp are dropped.
+	 *
+	 * @param string             $rrule        RRULE string (without DTSTART).
+	 * @param int                $master_start Master start, unix UTC.
+	 * @param int                $master_end   Master end, unix UTC.
+	 * @param int                $range_start  Range start, unix UTC (inclusive).
+	 * @param int                $range_end    Range end, unix UTC (inclusive).
+	 * @param int[]              $exceptions   EXDATE start timestamps to skip (unix UTC).
+	 * @param \DateTimeZone|null $timezone     Wall-clock timezone for expansion. Defaults to UTC.
+	 *
+	 * @return array<int, array{start:int, end:int}> Occurrences as unix UTC start/end pairs.
+	 */
+	public static function expand_in_range( $rrule, $master_start, $master_end, $range_start, $range_end, $exceptions = array(), $timezone = null ) {
+		if ( ! self::is_recurring( $rrule ) ) {
+			return array();
+		}
+
+		$tz = $timezone instanceof DateTimeZone ? $timezone : new DateTimeZone( 'UTC' );
+
+		$duration = (int) $master_end - (int) $master_start;
+
+		// A negative duration is malformed (end before start); refuse to emit
+		// inverted occurrences that would corrupt downstream conflict math.
+		if ( $duration < 0 ) {
+			return array();
+		}
+
+		// Keyed lookup so EXDATE matching is O(1) per occurrence.
+		$exclusion = array_flip( array_map( 'intval', $exceptions ) );
+
+		// DTSTART anchors the rule at the master's local wall-clock time so the
+		// library keeps that time stable across DST.
+		$dtstart = new DateTime( '@' . (int) $master_start );
+		$dtstart->setTimezone( $tz );
+
+		$rule = new RRule( (string) $rrule, $dtstart );
+
+		// Expand a touch wider than the range: an occurrence can start before
+		// the range yet still overlap it (long/multi-day appointments).
+		$begin = new DateTime( '@' . ( (int) $range_start - $duration ) );
+		$begin->setTimezone( $tz );
+		$end = new DateTime( '@' . (int) $range_end );
+		$end->setTimezone( $tz );
+
+		$occurrences = array();
+
+		foreach ( $rule->getOccurrencesBetween( $begin, $end ) as $occurrence ) {
+			$occ_start = (int) $occurrence->getTimestamp();
+			$occ_end   = $occ_start + $duration;
+
+			if ( isset( $exclusion[ $occ_start ] ) ) {
+				continue;
+			}
+
+			// Keep only occurrences that actually overlap the requested range.
+			// An occurrence ending exactly at range_start does not overlap.
+			if ( $occ_end <= (int) $range_start || $occ_start > (int) $range_end ) {
+				continue;
+			}
+
+			$occurrences[] = array(
+				'start' => $occ_start,
+				'end'   => $occ_end,
+			);
+
+			if ( count( $occurrences ) >= self::MAX_OCCURRENCES ) {
+				break;
+			}
+		}
+
+		return $occurrences;
+	}
+}

--- a/plugins/appstip-appointments/tests/php/Api/Endpoints/AppointmentsControllerTest.php
+++ b/plugins/appstip-appointments/tests/php/Api/Endpoints/AppointmentsControllerTest.php
@@ -224,6 +224,124 @@ test(
 );
 
 test(
+	'POST wpappointments/v1/appointments - stores a valid rrule and exceptions',
+	function () {
+		// Log in as admin.
+		wp_set_current_user( 1 );
+
+		$exception = time() + 7 * DAY_IN_SECONDS;
+
+		$results = $this->do_rest_post_request(
+			'appointments',
+			array(
+				'date'                 => time() + 3600,
+				'service'              => 'Recurring service',
+				'duration'             => 60,
+				'customer'             => array(
+					'name'  => 'John Doe',
+					'email' => 'john@example.com',
+					'phone' => '+1 (000) 000-0000',
+				),
+				'customerId'           => 1,
+				'status'               => 'confirmed',
+				'rrule'                => 'FREQ=WEEKLY;COUNT=4',
+				'recurrenceExceptions' => array( $exception ),
+			)
+		);
+
+		$data = $results->get_data();
+
+		expect( $results )->toBeSuccess();
+		expect( $data['data']['appointment']['rrule'] )->toBe( 'FREQ=WEEKLY;COUNT=4' );
+		expect( $data['data']['appointment']['recurrenceExceptions'] )->toBe( array( $exception ) );
+	}
+);
+
+test(
+	'POST wpappointments/v1/appointments - rejects an invalid rrule',
+	function () {
+		// Log in as admin.
+		wp_set_current_user( 1 );
+
+		$results = $this->do_rest_post_request(
+			'appointments',
+			array(
+				'date'       => time() + 3600,
+				'service'    => 'Bad rule',
+				'duration'   => 60,
+				'customer'   => array(
+					'name'  => 'John Doe',
+					'email' => 'john@example.com',
+					'phone' => '+1 (000) 000-0000',
+				),
+				'customerId' => 1,
+				'status'     => 'confirmed',
+				'rrule'      => 'TOTALLY-NOT-AN-RRULE',
+			)
+		);
+
+		expect( $results )->toBeError( 422, 'invalid_rrule' );
+	}
+);
+
+test(
+	'POST wpappointments/v1/appointments - rejects a sub-daily recurrence frequency',
+	function () {
+		// Log in as admin.
+		wp_set_current_user( 1 );
+
+		$results = $this->do_rest_post_request(
+			'appointments',
+			array(
+				'date'       => time() + 3600,
+				'service'    => 'Abusive rule',
+				'duration'   => 60,
+				'customer'   => array(
+					'name'  => 'John Doe',
+					'email' => 'john@example.com',
+					'phone' => '+1 (000) 000-0000',
+				),
+				'customerId' => 1,
+				'status'     => 'confirmed',
+				'rrule'      => 'FREQ=MINUTELY;COUNT=100000',
+			)
+		);
+
+		expect( $results )->toBeError( 422, 'invalid_rrule' );
+	}
+);
+
+test(
+	'POST wpappointments/v1/appointments - rejects too many recurrence exceptions',
+	function () {
+		// Log in as admin.
+		wp_set_current_user( 1 );
+
+		$too_many = array_fill( 0, 1001, time() );
+
+		$results = $this->do_rest_post_request(
+			'appointments',
+			array(
+				'date'                 => time() + 3600,
+				'service'              => 'Too many exceptions',
+				'duration'             => 60,
+				'customer'             => array(
+					'name'  => 'John Doe',
+					'email' => 'john@example.com',
+					'phone' => '+1 (000) 000-0000',
+				),
+				'customerId'           => 1,
+				'status'               => 'confirmed',
+				'rrule'                => 'FREQ=WEEKLY;COUNT=4',
+				'recurrenceExceptions' => $too_many,
+			)
+		);
+
+		expect( $results )->toBeError( 422, 'too_many_exceptions' );
+	}
+);
+
+test(
 	'POST wpappointments/v1/appointments - status 200 - with created customer',
 	function () {
 		// Log in as admin.

--- a/plugins/appstip-appointments/tests/php/Data/Model/AppointmentTest.php
+++ b/plugins/appstip-appointments/tests/php/Data/Model/AppointmentTest.php
@@ -783,3 +783,161 @@ test(
 		expect( $normalized['all_day'] )->toBeTrue();
 	}
 );
+
+test(
+	'Appointment model - default_normalizer exposes recurrence fields',
+	function () {
+		$id = wp_insert_post(
+			array(
+				'post_title'  => 'Recurring',
+				'post_status' => 'publish',
+				'post_type'   => 'wpa-appointment',
+				'meta_input'  => array(
+					'timestamp'             => 1000000,
+					'duration'              => 60,
+					'status'                => 'confirmed',
+					'rrule'                 => 'FREQ=WEEKLY;COUNT=4',
+					'recurrence_exceptions' => array( 1000000 ),
+				),
+			)
+		);
+
+		$normalized = ( new Appointment( $id ) )->normalize();
+
+		expect( $normalized['rrule'] )->toBe( 'FREQ=WEEKLY;COUNT=4' );
+		expect( $normalized['recurrence_exceptions'] )->toBe( array( 1000000 ) );
+		expect( $normalized['recurrence_parent'] )->toBe( 0 );
+	}
+);
+
+test(
+	'Appointment model - default_normalizer recurrence fields default empty when absent',
+	function () {
+		$id = wp_insert_post(
+			array(
+				'post_title'  => 'Plain',
+				'post_status' => 'publish',
+				'post_type'   => 'wpa-appointment',
+				'meta_input'  => array(
+					'timestamp' => 1000000,
+					'duration'  => 60,
+					'status'    => 'confirmed',
+				),
+			)
+		);
+
+		$normalized = ( new Appointment( $id ) )->normalize();
+
+		expect( $normalized['rrule'] )->toBe( '' );
+		expect( $normalized['recurrence_exceptions'] )->toBe( array() );
+		expect( $normalized['recurrence_parent'] )->toBe( 0 );
+	}
+);
+
+test(
+	'Appointment model - detach_occurrence creates a detached child and EXDATEs the master',
+	function () {
+		$master_start = 1000000;
+		$duration     = 60;
+
+		$master_id = wp_insert_post(
+			array(
+				'post_title'  => 'Weekly standup',
+				'post_status' => 'publish',
+				'post_type'   => 'wpa-appointment',
+				'meta_input'  => array(
+					'timestamp'   => $master_start,
+					'duration'    => $duration,
+					'status'      => 'confirmed',
+					'customer_id' => 7,
+					'rrule'       => 'FREQ=WEEKLY;COUNT=4',
+				),
+			)
+		);
+
+		// Detach the second occurrence (one week after the master start).
+		$occurrence_ts = $master_start + 7 * DAY_IN_SECONDS;
+
+		$child = ( new Appointment( $master_id ) )->detach_occurrence( $occurrence_ts );
+
+		expect( $child )->toBeInstanceOf( Appointment::class );
+
+		$child_data = $child->normalize();
+
+		// Child is a plain, non-recurring appointment linked back to the master.
+		expect( $child_data['rrule'] )->toBe( '' );
+		expect( $child_data['recurrence_parent'] )->toBe( $master_id );
+		expect( $child_data['timestamp'] )->toBe( $occurrence_ts );
+		expect( $child_data['end_timestamp'] )->toBe( $occurrence_ts + $duration * 60 );
+		expect( (int) $child->appointment->post_parent )->toBe( $master_id );
+
+		// Inherited meta carries over.
+		expect( $child_data['customer_id'] )->toBe( 7 );
+
+		// Master now EXDATEs the detached occurrence.
+		$master_after = ( new Appointment( $master_id ) )->normalize();
+		expect( $master_after['recurrence_exceptions'] )->toContain( $occurrence_ts );
+	}
+);
+
+test(
+	'Appointment model - detach_occurrence is idempotent - a second detach of the same occurrence errors',
+	function () {
+		$master_start = 1000000;
+
+		$master_id = wp_insert_post(
+			array(
+				'post_title'  => 'Weekly standup',
+				'post_status' => 'publish',
+				'post_type'   => 'wpa-appointment',
+				'meta_input'  => array(
+					'timestamp'   => $master_start,
+					'duration'    => 60,
+					'status'      => 'confirmed',
+					'customer_id' => 7,
+					'rrule'       => 'FREQ=WEEKLY;COUNT=4',
+				),
+			)
+		);
+
+		$occurrence_ts = $master_start + 7 * DAY_IN_SECONDS;
+
+		$first = ( new Appointment( $master_id ) )->detach_occurrence( $occurrence_ts );
+		expect( $first )->toBeInstanceOf( Appointment::class );
+
+		// Detaching the same occurrence again must not create a second child.
+		$second = ( new Appointment( $master_id ) )->detach_occurrence( $occurrence_ts );
+		expect( $second )->toBeWPError( 'occurrence_already_detached' );
+
+		$children = get_children(
+			array(
+				'post_parent' => $master_id,
+				'post_type'   => 'wpa-appointment',
+				'post_status' => 'publish',
+			)
+		);
+		expect( count( $children ) )->toBe( 1 );
+	}
+);
+
+test(
+	'Appointment model - detach_occurrence on a non-recurring appointment errors',
+	function () {
+		$id = wp_insert_post(
+			array(
+				'post_title'  => 'One off',
+				'post_status' => 'publish',
+				'post_type'   => 'wpa-appointment',
+				'meta_input'  => array(
+					'timestamp' => 1000000,
+					'duration'  => 60,
+					'status'    => 'confirmed',
+				),
+			)
+		);
+
+		$result = ( new Appointment( $id ) )->detach_occurrence( 1000000 );
+
+		expect( $result )->toBeWPError( 'appointment_not_recurring' );
+	}
+);

--- a/plugins/appstip-appointments/tests/php/Data/Query/AppointmentsQueryTest.php
+++ b/plugins/appstip-appointments/tests/php/Data/Query/AppointmentsQueryTest.php
@@ -168,3 +168,97 @@ test(
 		expect( $by_id[ $multi ]['allDay'] )->toBeFalse();
 	}
 );
+
+test(
+	'AppointmentsQuery::get_date_range_appointments expands a recurring master into occurrences',
+	function () {
+		$utc          = new \DateTimeZone( 'UTC' );
+		$master_start = ( new \DateTime( '2026-06-01 10:00:00', $utc ) )->getTimestamp();
+
+		$master_id = wp_insert_post(
+			array(
+				'post_type'   => 'wpa-appointment',
+				'post_status' => 'publish',
+				'post_title'  => 'Weekly',
+				'meta_input'  => array(
+					'status'    => 'confirmed',
+					'timestamp' => $master_start,
+					'duration'  => 60,
+					'rrule'     => 'FREQ=WEEKLY;COUNT=4',
+				),
+			)
+		);
+
+		$range_start = $master_start - DAY_IN_SECONDS;
+		$range_end   = $master_start + 5 * 7 * DAY_IN_SECONDS;
+
+		$results = AppointmentsQuery::get_date_range_appointments( $range_start, $range_end );
+
+		// Master is not returned as a raw single row; only its 4 occurrences.
+		$occurrences = array_values(
+			array_filter(
+				$results['appointments'],
+				function ( $appointment ) use ( $master_id ) {
+					return $appointment['id'] === $master_id;
+				}
+			)
+		);
+
+		expect( $occurrences )->toHaveCount( 4 );
+
+		$starts = wp_list_pluck( $occurrences, 'timestamp' );
+		sort( $starts );
+
+		expect( $starts[0] )->toBe( $master_start );
+		expect( $starts[1] )->toBe( $master_start + 7 * DAY_IN_SECONDS );
+
+		// Each occurrence preserves the master duration.
+		foreach ( $occurrences as $occurrence ) {
+			expect( $occurrence['endTimestamp'] - $occurrence['timestamp'] )->toBe( 60 * 60 );
+		}
+	}
+);
+
+test(
+	'AppointmentsQuery::get_date_range_appointments honours recurrence_exceptions',
+	function () {
+		$utc          = new \DateTimeZone( 'UTC' );
+		$master_start = ( new \DateTime( '2026-06-01 10:00:00', $utc ) )->getTimestamp();
+		$dropped      = $master_start + 7 * DAY_IN_SECONDS;
+
+		$master_id = wp_insert_post(
+			array(
+				'post_type'   => 'wpa-appointment',
+				'post_status' => 'publish',
+				'post_title'  => 'Weekly with gap',
+				'meta_input'  => array(
+					'status'                => 'confirmed',
+					'timestamp'             => $master_start,
+					'duration'              => 60,
+					'rrule'                 => 'FREQ=WEEKLY;COUNT=4',
+					'recurrence_exceptions' => array( $dropped ),
+				),
+			)
+		);
+
+		$results = AppointmentsQuery::get_date_range_appointments(
+			$master_start - DAY_IN_SECONDS,
+			$master_start + 5 * 7 * DAY_IN_SECONDS
+		);
+
+		$starts = wp_list_pluck(
+			array_values(
+				array_filter(
+					$results['appointments'],
+					function ( $appointment ) use ( $master_id ) {
+						return $appointment['id'] === $master_id;
+					}
+				)
+			),
+			'timestamp'
+		);
+
+		expect( $starts )->toHaveCount( 3 );
+		expect( $starts )->not->toContain( $dropped );
+	}
+);

--- a/plugins/appstip-appointments/tests/php/Recurrence/RecurrenceExpanderTest.php
+++ b/plugins/appstip-appointments/tests/php/Recurrence/RecurrenceExpanderTest.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Recurrence Expander Test
+ *
+ * @package WPAppointments
+ */
+
+namespace Tests\Recurrence;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use WPAppointments\Recurrence\RecurrenceExpander;
+
+uses( \TestTools\TestCase::class )->group( 'recurrence' );
+
+test(
+	'RecurrenceExpander::expand_in_range - weekly expands to four occurrences seven days apart',
+	function () {
+		$utc = new \DateTimeZone( 'UTC' );
+
+		$master_start = ( new \DateTime( '2026-06-01 10:00:00', $utc ) )->getTimestamp();
+		$master_end   = $master_start + 3600;
+
+		$range_start = ( new \DateTime( '2026-06-01 00:00:00', $utc ) )->getTimestamp();
+		$range_end   = ( new \DateTime( '2026-07-15 00:00:00', $utc ) )->getTimestamp();
+
+		$occurrences = RecurrenceExpander::expand_in_range(
+			'FREQ=WEEKLY;COUNT=4',
+			$master_start,
+			$master_end,
+			$range_start,
+			$range_end,
+			array(),
+			$utc
+		);
+
+		expect( $occurrences )->toHaveCount( 4 );
+
+		// First occurrence equals the master start (DTSTART).
+		expect( $occurrences[0]['start'] )->toBe( $master_start );
+
+		// Each subsequent occurrence is exactly seven days after the previous.
+		$count = count( $occurrences );
+		for ( $i = 1; $i < $count; $i++ ) {
+			expect( $occurrences[ $i ]['start'] - $occurrences[ $i - 1 ]['start'] )->toBe( 7 * DAY_IN_SECONDS );
+		}
+
+		// Duration is preserved on every occurrence.
+		foreach ( $occurrences as $occurrence ) {
+			expect( $occurrence['end'] - $occurrence['start'] )->toBe( 3600 );
+		}
+	}
+);
+
+test(
+	'RecurrenceExpander::expand_in_range - EXDATE drops the matching occurrence',
+	function () {
+		$utc = new \DateTimeZone( 'UTC' );
+
+		$master_start = ( new \DateTime( '2026-06-01 10:00:00', $utc ) )->getTimestamp();
+		$master_end   = $master_start + 3600;
+
+		$range_start = $master_start - DAY_IN_SECONDS;
+		$range_end   = $master_start + 5 * 7 * DAY_IN_SECONDS;
+
+		$full = RecurrenceExpander::expand_in_range(
+			'FREQ=WEEKLY;COUNT=4',
+			$master_start,
+			$master_end,
+			$range_start,
+			$range_end,
+			array(),
+			$utc
+		);
+
+		$dropped = $full[1]['start'];
+
+		$with_exception = RecurrenceExpander::expand_in_range(
+			'FREQ=WEEKLY;COUNT=4',
+			$master_start,
+			$master_end,
+			$range_start,
+			$range_end,
+			array( $dropped ),
+			$utc
+		);
+
+		expect( $with_exception )->toHaveCount( 3 );
+		expect( wp_list_pluck( $with_exception, 'start' ) )->not->toContain( $dropped );
+	}
+);
+
+test(
+	'RecurrenceExpander::expand_in_range - returns only occurrences overlapping the range',
+	function () {
+		$utc = new \DateTimeZone( 'UTC' );
+
+		$master_start = ( new \DateTime( '2026-06-01 10:00:00', $utc ) )->getTimestamp();
+		$master_end   = $master_start + 3600;
+
+		// Window only the second and third weekly occurrences.
+		$second = $master_start + 7 * DAY_IN_SECONDS;
+		$third  = $master_start + 14 * DAY_IN_SECONDS;
+
+		$occurrences = RecurrenceExpander::expand_in_range(
+			'FREQ=WEEKLY;COUNT=8',
+			$master_start,
+			$master_end,
+			$second - 60,
+			$third + 3660,
+			array(),
+			$utc
+		);
+
+		expect( $occurrences )->toHaveCount( 2 );
+		expect( $occurrences[0]['start'] )->toBe( $second );
+		expect( $occurrences[1]['start'] )->toBe( $third );
+	}
+);
+
+test(
+	'RecurrenceExpander::expand_in_range - preserves local wall-clock time across a DST transition',
+	function () {
+		$tz = new \DateTimeZone( 'Europe/Warsaw' );
+
+		// Monday before the 2026-03-29 spring-forward transition.
+		$master_start = ( new \DateTime( '2026-03-23 10:00:00', $tz ) )->getTimestamp();
+		$master_end   = $master_start + 3600;
+
+		$range_start = ( new \DateTime( '2026-03-20 00:00:00', $tz ) )->getTimestamp();
+		$range_end   = ( new \DateTime( '2026-04-10 00:00:00', $tz ) )->getTimestamp();
+
+		$occurrences = RecurrenceExpander::expand_in_range(
+			'FREQ=WEEKLY;COUNT=3',
+			$master_start,
+			$master_end,
+			$range_start,
+			$range_end,
+			array(),
+			$tz
+		);
+
+		expect( $occurrences )->toHaveCount( 3 );
+
+		foreach ( $occurrences as $occurrence ) {
+			$local = ( new \DateTime( '@' . $occurrence['start'] ) )->setTimezone( $tz );
+			expect( $local->format( 'H:i' ) )->toBe( '10:00' );
+		}
+
+		// The unix gap across the spring-forward week is one hour shorter,
+		// proving expansion is timezone-aware rather than naive 7*86400.
+		expect( $occurrences[1]['start'] - $occurrences[0]['start'] )->toBe( 7 * DAY_IN_SECONDS - HOUR_IN_SECONDS );
+	}
+);
+
+test(
+	'RecurrenceExpander::is_recurring - detects presence of an rrule',
+	function () {
+		expect( RecurrenceExpander::is_recurring( 'FREQ=WEEKLY' ) )->toBeTrue();
+		expect( RecurrenceExpander::is_recurring( '' ) )->toBeFalse();
+		expect( RecurrenceExpander::is_recurring( '   ' ) )->toBeFalse();
+		expect( RecurrenceExpander::is_recurring( null ) )->toBeFalse();
+	}
+);
+
+test(
+	'RecurrenceExpander::expand_in_range - an occurrence ending exactly at range_start does not overlap',
+	function () {
+		$utc = new \DateTimeZone( 'UTC' );
+
+		$master_start = ( new \DateTime( '2026-06-01 10:00:00', $utc ) )->getTimestamp();
+		$master_end   = $master_start + 3600;
+
+		// Range begins exactly when the first occurrence ends: zero overlap, so
+		// the first occurrence must be excluded and only the rest returned.
+		$occurrences = RecurrenceExpander::expand_in_range(
+			'FREQ=WEEKLY;COUNT=4',
+			$master_start,
+			$master_end,
+			$master_end,
+			$master_start + 5 * 7 * DAY_IN_SECONDS,
+			array(),
+			$utc
+		);
+
+		expect( $occurrences )->toHaveCount( 3 );
+		expect( wp_list_pluck( $occurrences, 'start' ) )->not->toContain( $master_start );
+	}
+);
+
+test(
+	'RecurrenceExpander::expand_in_range - a negative duration master yields no occurrences',
+	function () {
+		$utc = new \DateTimeZone( 'UTC' );
+
+		$master_start = ( new \DateTime( '2026-06-01 10:00:00', $utc ) )->getTimestamp();
+
+		$occurrences = RecurrenceExpander::expand_in_range(
+			'FREQ=DAILY;COUNT=3',
+			$master_start,
+			$master_start - 100,
+			$master_start,
+			$master_start + 30 * DAY_IN_SECONDS,
+			array(),
+			$utc
+		);
+
+		expect( $occurrences )->toBe( array() );
+	}
+);
+
+test(
+	'RecurrenceExpander::expand_in_range - caps runaway expansion at MAX_OCCURRENCES',
+	function () {
+		$utc = new \DateTimeZone( 'UTC' );
+
+		$master_start = ( new \DateTime( '2026-06-01 10:00:00', $utc ) )->getTimestamp();
+		$master_end   = $master_start + 3600;
+
+		// Unbounded daily rule over a multi-decade range would expand to ~18k
+		// occurrences; the hard cap must keep it bounded.
+		$occurrences = RecurrenceExpander::expand_in_range(
+			'FREQ=DAILY',
+			$master_start,
+			$master_end,
+			$master_start,
+			$master_start + 5000 * DAY_IN_SECONDS,
+			array(),
+			$utc
+		);
+
+		expect( $occurrences )->toHaveCount( RecurrenceExpander::MAX_OCCURRENCES );
+	}
+);


### PR DESCRIPTION
## What

CORE-A2: appointment recurrence, built on the CORE-A1 seams (#460). A master appointment stores an `rrule` (+ optional `recurrence_exceptions` EXDATEs); virtual occurrences are **expanded on read** for both the calendar listing and conflict checks. Core owns the expander so recurring bookings and (future) schedule recurrence share one engine.

Stacked on #460 (`feat/appointment-model-seams`) — review/merge that first.

## Changes
- **`src/Recurrence/RecurrenceExpander`** — wraps `rlanvin/php-rrule`, expands within a range, preserves per-occurrence duration, applies EXDATEs (O(1) lookup), anchors DTSTART in the site timezone so wall-clock time stays stable across DST, and hard-caps output (`MAX_OCCURRENCES = 1000`) against runaway rules.
- **`AppointmentsController`** — accept + validate `rrule`/`recurrenceExceptions` on both create endpoints; reject malformed, sub-daily (`SECONDLY`/`MINUTELY`), and oversized exception lists with 422; emit recurrence fields in `normalize()`.
- **`Appointment::detach_occurrence`** — edit-single = detached child (`post_parent` + `recurrence_parent` meta) **and** EXDATE the master so the series stops expanding that slot. Idempotent: a second detach of the same occurrence errors (`occurrence_already_detached`).
- **`AppointmentsQuery`** — expand recurring masters on read, excluding their raw row (`rrule NOT EXISTS`) so the first instance isn't double-counted; pagination total corrected for expanded sets.

## Safety / correctness (from adversarial review)
- DoS hardening: sub-daily frequencies and >1000 exceptions rejected at create; expander hard-caps occurrences and bounds to the query range.
- Dedup invariant: edit-single adds the EXDATE that suppresses the master occurrence, so an edited slot appears exactly once (child row), never double-booked.
- DST: occurrences keep local wall-clock time (verified across a Europe/Warsaw spring-forward).

## Backward compatibility
Additive. With no `rrule`, every path behaves as before and the expansion query returns early (zero overhead on non-recurring installs).

## Dependency
Adds `rlanvin/php-rrule:^2.6` (MIT). `vendor/` stays gitignored; the release script (`.scripts/release`) already bundles deps via `composer install --no-dev`, and `composer.lock` is committed.

## Tests
Full Pest suite green locally: **303 passed** (base was 282). New coverage: expander (weekly/EXDATE/range/DST/boundary/negative-duration/cap), model (recurrence normalize + detach happy/non-recurring/idempotent), query (expansion + EXDATE), controller (store rrule, reject invalid/sub-daily/too-many-exceptions). `phpcs` clean.

