### PR TITLE
feat(appointments): multi-day & all-day appointment form UI (Lane 4)

### DIFF
--- a/plugins/appstip-appointments/assets/backend/admin/components/AppointmentForm/AppointmentForm.tsx
+++ b/plugins/appstip-appointments/assets/backend/admin/components/AppointmentForm/AppointmentForm.tsx
@@ -90,6 +90,7 @@ export default function AppointmentForm({ defaultDate }: FormProps) {
 	const [formData, setFormData] =
 		useState<AppointmentFormFields>(defaultFormData);
 	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [showEndDate, setShowEndDate] = useState(false);
 
 	const setField = <K extends keyof AppointmentFormFields>(
 		field: K,
@@ -171,6 +172,10 @@ export default function AppointmentForm({ defaultDate }: FormProps) {
 			const endDate = currentAppointment.endTimestamp
 				? new Date(currentAppointment.endTimestamp * 1000)
 				: null;
+
+			// Reveal the end-date calendar when editing an appointment that
+			// already has an end date set.
+			setShowEndDate(!!endDate);
 
 			setFormData((prev) => ({
 				...prev,
@@ -646,50 +651,66 @@ export default function AppointmentForm({ defaultDate }: FormProps) {
 									'appstip-appointments'
 								)}
 							</span>
-							<WPDatePicker
-								currentDate={
-									formData.endDate ||
-									formData.date ||
-									defaultDateToday.toISOString()
-								}
-								onChange={(newDate) => {
-									if (newDate) {
-										setField('endDate', newDate);
-									}
-								}}
-								isInvalidDate={(d) => {
-									if (!formData.date) {
-										return false;
-									}
+							{showEndDate || formData.endDate ? (
+								<>
+									<WPDatePicker
+										currentDate={
+											formData.endDate ||
+											formData.date ||
+											defaultDateToday.toISOString()
+										}
+										onChange={(newDate) => {
+											if (newDate) {
+												setField('endDate', newDate);
+											}
+										}}
+										isInvalidDate={(d) => {
+											if (!formData.date) {
+												return false;
+											}
 
-									return isBefore(
-										startOfDay(d),
-										startOfDay(new Date(formData.date))
-									);
-								}}
-								startOfWeek={
-									window.wpappointments.date.startOfWeek as
-										| 0
-										| 1
-										| 2
-										| 3
-										| 4
-										| 5
-										| 6
-								}
-								events={[]}
-							/>
-							{formData.endDate && (
+											return isBefore(
+												startOfDay(d),
+												startOfDay(
+													new Date(formData.date)
+												)
+											);
+										}}
+										startOfWeek={
+											window.wpappointments.date
+												.startOfWeek as
+												| 0
+												| 1
+												| 2
+												| 3
+												| 4
+												| 5
+												| 6
+										}
+										events={[]}
+									/>
+									<Button
+										size="small"
+										variant="tertiary"
+										isDestructive
+										onClick={() => {
+											setField('endDate', '');
+											setShowEndDate(false);
+										}}
+									>
+										{__(
+											'Clear end date',
+											'appstip-appointments'
+										)}
+									</Button>
+								</>
+							) : (
 								<Button
+									variant="secondary"
 									size="small"
-									variant="tertiary"
-									isDestructive
-									onClick={() => setField('endDate', '')}
+									onClick={() => setShowEndDate(true)}
 								>
-									{__(
-										'Clear end date',
-										'appstip-appointments'
-									)}
+									{__('Add end date', 'appstip-appointments')}
 								</Button>
 							)}
 						</FormFieldSet>

--- a/plugins/appstip-appointments/assets/backend/admin/components/AppointmentForm/AppointmentForm.tsx
+++ b/plugins/appstip-appointments/assets/backend/admin/components/AppointmentForm/AppointmentForm.tsx
@@ -1,4 +1,4 @@
-import { Button, SelectControl } from '@wordpress/components';
+import { Button, SelectControl, ToggleControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -8,10 +8,11 @@ import {
 	formFieldStyles,
 	FormFieldSet,
 	SlideOut,
+	WPDatePicker,
 } from '@wpappointments/components';
 import { displayErrorToast } from '@wpappointments/data';
 import { useSlideout } from '@wpappointments/data';
-import { addMinutes } from 'date-fns';
+import { addMinutes, isBefore, startOfDay } from 'date-fns';
 import { safeParse } from 'valibot';
 import { APIResponse } from '~/backend/utils/fetch';
 import { formatTimeForPicker } from '~/backend/utils/format';
@@ -38,6 +39,8 @@ export type AppointmentFormFields = {
 	timeMinuteStart: string;
 	timeType: 'am' | 'pm';
 	duration: number;
+	allDay: boolean;
+	endDate: string;
 	customer: {
 		id: number;
 		name: string;
@@ -68,6 +71,8 @@ const defaultFormData: AppointmentFormFields = {
 	timeMinuteStart: '',
 	timeType: 'am',
 	duration: 0,
+	allDay: false,
+	endDate: '',
 	customer: {
 		id: 0,
 		name: '',
@@ -163,6 +168,9 @@ export default function AppointmentForm({ defaultDate }: FormProps) {
 			}
 
 			const date = new Date(currentAppointment.timestamp * 1000);
+			const endDate = currentAppointment.endTimestamp
+				? new Date(currentAppointment.endTimestamp * 1000)
+				: null;
 
 			setFormData((prev) => ({
 				...prev,
@@ -173,6 +181,8 @@ export default function AppointmentForm({ defaultDate }: FormProps) {
 				timeHourStart: formatTimeForPicker(date.getHours()),
 				timeMinuteStart: formatTimeForPicker(date.getMinutes()),
 				duration: currentAppointment.duration,
+				allDay: currentAppointment.allDay || false,
+				endDate: endDate ? endDate.toISOString() : '',
 				customer: {
 					...prev.customer,
 					name: currentAppointment.customer.name,
@@ -201,10 +211,16 @@ export default function AppointmentForm({ defaultDate }: FormProps) {
 	const onSubmit = async () => {
 		if (isSubmitting) return;
 
+		if (!formData.date) {
+			displayErrorToast(
+				__('Please select a date.', 'appstip-appointments')
+			);
+			return;
+		}
+
 		if (
-			!formData.date ||
-			!formData.timeHourStart ||
-			!formData.timeMinuteStart
+			!formData.allDay &&
+			(!formData.timeHourStart || !formData.timeMinuteStart)
 		) {
 			displayErrorToast(
 				__('Please select a date and time.', 'appstip-appointments')
@@ -213,8 +229,14 @@ export default function AppointmentForm({ defaultDate }: FormProps) {
 		}
 
 		const date = new Date(formData.date);
-		date.setHours(parseInt(formData.timeHourStart, 10));
-		date.setMinutes(parseInt(formData.timeMinuteStart, 10));
+
+		if (formData.allDay) {
+			date.setHours(0);
+			date.setMinutes(0);
+		} else {
+			date.setHours(parseInt(formData.timeHourStart, 10));
+			date.setMinutes(parseInt(formData.timeMinuteStart, 10));
+		}
 		date.setSeconds(0);
 		date.setMilliseconds(0);
 
@@ -225,6 +247,48 @@ export default function AppointmentForm({ defaultDate }: FormProps) {
 			return;
 		}
 
+		let endDateIso: string | undefined;
+
+		if (formData.endDate) {
+			const endDate = new Date(formData.endDate);
+
+			if (isNaN(endDate.getTime())) {
+				displayErrorToast(
+					__('Invalid end date.', 'appstip-appointments')
+				);
+				return;
+			}
+
+			if (isBefore(startOfDay(endDate), startOfDay(date))) {
+				displayErrorToast(
+					__(
+						'End date cannot be before the start date.',
+						'appstip-appointments'
+					)
+				);
+				return;
+			}
+
+			// Multi-day span end time: mirror the start time-of-day, or
+			// end-of-day for all-day appointments. Only send endDate when it
+			// resolves to a moment strictly after the start, matching the
+			// backend requirement for setting the end_timestamp meta.
+			if (formData.allDay) {
+				endDate.setHours(23);
+				endDate.setMinutes(59);
+				endDate.setSeconds(59);
+			} else {
+				endDate.setHours(parseInt(formData.timeHourStart, 10));
+				endDate.setMinutes(parseInt(formData.timeMinuteStart, 10));
+				endDate.setSeconds(0);
+			}
+			endDate.setMilliseconds(0);
+
+			if (endDate.getTime() > date.getTime()) {
+				endDateIso = endDate.toISOString();
+			}
+		}
+
 		const submitData = {
 			...formData,
 			service:
@@ -233,6 +297,11 @@ export default function AppointmentForm({ defaultDate }: FormProps) {
 				defaultEntityName.toLowerCase(),
 			date: date.toISOString(),
 			entityId: coreEntityId,
+			allDay: formData.allDay,
+			// Overwrite the raw local-only `endDate` field: send the computed
+			// ISO end date, or `undefined` (dropped by JSON serialization) when
+			// there is no valid multi-day end.
+			endDate: endDateIso,
 		};
 
 		setIsSubmitting(true);
@@ -434,56 +503,197 @@ export default function AppointmentForm({ defaultDate }: FormProps) {
 
 					<FormFieldSet
 						legend={__('Date and time', 'appstip-appointments')}
-						style={{
-							display: formData.datetime ? 'none' : 'block',
-						}}
 					>
-						<FormFieldSet horizontal horizontalCenter>
-							<span className={styles.noTimeLabel}>
-								{__('No time selected', 'appstip-appointments')}
-							</span>
-							<Button
-								variant="secondary"
-								size="small"
-								onClick={() => {
-									openSlideOut({
-										id: `select-time`,
-										data: {
-											defaultDate,
-											defaultDateToday,
-										},
-									});
-								}}
-							>
-								{__('Select time', 'appstip-appointments')}
-							</Button>
-						</FormFieldSet>
-					</FormFieldSet>
+						<ToggleControl
+							onChange={(value) => {
+								if (value) {
+									// Switching to all-day: seed the start day
+									// from any already-selected date/today so the
+									// appointment still has a date, and drop the
+									// clock time fields.
+									const startDay = new Date(
+										formData.date || defaultDateToday
+									);
+									setFormData((prev) => ({
+										...prev,
+										allDay: true,
+										date: startDay.toISOString(),
+										datetime: startDay.getTime().toString(),
+										timeHourStart: '',
+										timeMinuteStart: '',
+									}));
+								} else {
+									setField('allDay', false);
+								}
+							}}
+							checked={formData.allDay}
+							label={__('All day', 'appstip-appointments')}
+							__nextHasNoMarginBottom
+						/>
 
-					{formData.datetime && formData.date && (
-						<Summary
-							date={new Date(formData.date)}
-							timeHourStart={formData.timeHourStart}
-							timeMinuteStart={formData.timeMinuteStart}
-							timeHourEnd={timeHourEnd}
-							timeMinuteEnd={timeMinuteEnd}
-							duration={formData.duration}
-							showAvailabilityWarning={false}
-							headerActions={
-								<Button
-									size="small"
-									variant="secondary"
-									onClick={() => {
-										openSlideOut({
-											id: 'select-time',
-										});
+						{formData.allDay ? (
+							<FormFieldSet
+								legend={__('Start day', 'appstip-appointments')}
+								style={{ maxWidth: '300px' }}
+							>
+								<WPDatePicker
+									currentDate={
+										formData.date ||
+										defaultDateToday.toISOString()
+									}
+									onChange={(newDate) => {
+										if (newDate) {
+											const start = new Date(newDate);
+											setFormData((prev) => ({
+												...prev,
+												date: start.toISOString(),
+												datetime: start
+													.getTime()
+													.toString(),
+											}));
+										}
+									}}
+									startOfWeek={
+										window.wpappointments.date
+											.startOfWeek as
+											| 0
+											| 1
+											| 2
+											| 3
+											| 4
+											| 5
+											| 6
+									}
+									events={[]}
+								/>
+							</FormFieldSet>
+						) : (
+							<>
+								<FormFieldSet
+									horizontal
+									horizontalCenter
+									style={{
+										display: formData.datetime
+											? 'none'
+											: 'block',
 									}}
 								>
-									{__('Change', 'appstip-appointments')}
+									<span className={styles.noTimeLabel}>
+										{__(
+											'No time selected',
+											'appstip-appointments'
+										)}
+									</span>
+									<Button
+										variant="secondary"
+										size="small"
+										onClick={() => {
+											openSlideOut({
+												id: `select-time`,
+												data: {
+													defaultDate,
+													defaultDateToday,
+												},
+											});
+										}}
+									>
+										{__(
+											'Select time',
+											'appstip-appointments'
+										)}
+									</Button>
+								</FormFieldSet>
+
+								{formData.datetime && formData.date && (
+									<Summary
+										date={new Date(formData.date)}
+										timeHourStart={formData.timeHourStart}
+										timeMinuteStart={
+											formData.timeMinuteStart
+										}
+										timeHourEnd={timeHourEnd}
+										timeMinuteEnd={timeMinuteEnd}
+										duration={formData.duration}
+										showAvailabilityWarning={false}
+										headerActions={
+											<Button
+												size="small"
+												variant="secondary"
+												onClick={() => {
+													openSlideOut({
+														id: 'select-time',
+													});
+												}}
+											>
+												{__(
+													'Change',
+													'appstip-appointments'
+												)}
+											</Button>
+										}
+									/>
+								)}
+							</>
+						)}
+
+						<FormFieldSet
+							legend={__('End date', 'appstip-appointments')}
+							style={{ maxWidth: '300px' }}
+						>
+							<span className={styles.noTimeLabel}>
+								{__(
+									'Optional. Set to create a multi-day appointment.',
+									'appstip-appointments'
+								)}
+							</span>
+							<WPDatePicker
+								currentDate={
+									formData.endDate ||
+									formData.date ||
+									defaultDateToday.toISOString()
+								}
+								onChange={(newDate) => {
+									if (newDate) {
+										setField('endDate', newDate);
+									}
+								}}
+								isInvalidDate={(d) => {
+									if (!formData.date) {
+										return false;
+									}
+
+									return isBefore(
+										startOfDay(d),
+										startOfDay(new Date(formData.date))
+									);
+								}}
+								startOfWeek={
+									window.wpappointments.date.startOfWeek as
+										| 0
+										| 1
+										| 2
+										| 3
+										| 4
+										| 5
+										| 6
+								}
+								events={[]}
+							/>
+							{formData.endDate && (
+								<Button
+									size="small"
+									variant="tertiary"
+									isDestructive
+									onClick={() => setField('endDate', '')}
+								>
+									{__(
+										'Clear end date',
+										'appstip-appointments'
+									)}
 								</Button>
-							}
-						/>
-					)}
+							)}
+						</FormFieldSet>
+					</FormFieldSet>
 
 					<FormFieldSet
 						legend={__('Customer', 'appstip-appointments')}

--- a/plugins/appstip-appointments/assets/backend/admin/components/AppointmentsTableFull/AppointmentsTableFull.module.css
+++ b/plugins/appstip-appointments/assets/backend/admin/components/AppointmentsTableFull/AppointmentsTableFull.module.css
@@ -6,6 +6,18 @@
 	font-weight: 500;
 }
 
+.badge {
+	display: inline-block;
+	margin-top: 4px;
+	margin-right: 4px;
+	padding: 2px 6px;
+	border-radius: 4px;
+	background-color: #e0e7ec;
+	color: #2e353b;
+	font-size: 11px;
+	font-weight: 500;
+}
+
 .pending {
 	background-color: #eaeaea;
 	color: #2e353b;

--- a/plugins/appstip-appointments/assets/backend/admin/components/AppointmentsTableFull/AppointmentsTableFull.tsx
+++ b/plugins/appstip-appointments/assets/backend/admin/components/AppointmentsTableFull/AppointmentsTableFull.tsx
@@ -6,7 +6,7 @@ import { cancelCircleFilled, check, edit, info, trash } from '@wordpress/icons';
 import { DataViews, TableFullEmpty } from '@wpappointments/components';
 import type { Action, Field, View } from '@wpappointments/components';
 import { useSlideout } from '@wpappointments/data';
-import { addMinutes, fromUnixTime } from 'date-fns';
+import { addMinutes, fromUnixTime, isSameDay } from 'date-fns';
 import cn from 'obj-str';
 import { userSiteTimezoneMatch } from '~/backend/utils/datetime';
 import { formatDate, formatTime } from '~/backend/utils/i18n';
@@ -33,6 +33,17 @@ const defaultView: View = {
 	fields: ['title', 'date', 'time', 'status'],
 	layout: {},
 };
+
+function isMultiDay(appointment: Appointment) {
+	if (!appointment.endTimestamp) {
+		return false;
+	}
+
+	return !isSameDay(
+		fromUnixTime(appointment.timestamp),
+		fromUnixTime(appointment.endTimestamp)
+	);
+}
 
 export default function AppointmentsTableFull() {
 	const { openSlideOut } = useSlideout({
@@ -125,6 +136,17 @@ export default function AppointmentsTableFull() {
 						<br />
 						{__('Customer', 'appstip-appointments')}:{' '}
 						<strong>{item.customer.name}</strong>
+						{(item.allDay || isMultiDay(item)) && <br />}
+						{item.allDay && (
+							<span className={styles.badge}>
+								{__('All day', 'appstip-appointments')}
+							</span>
+						)}
+						{isMultiDay(item) && (
+							<span className={styles.badge}>
+								{__('Multi-day', 'appstip-appointments')}
+							</span>
+						)}
 					</>
 				);
 			},

--- a/plugins/appstip-appointments/assets/backend/admin/pages/Calendar/Calendar.module.css
+++ b/plugins/appstip-appointments/assets/backend/admin/pages/Calendar/Calendar.module.css
@@ -93,6 +93,17 @@
 	text-overflow: ellipsis;
 }
 
+.event-badge {
+	display: inline-block;
+	margin-left: 4px;
+	padding: 0 4px;
+	border-radius: 2px;
+	background-color: rgba(255, 255, 255, 0.25);
+	font-size: 10px;
+	line-height: 14px;
+	text-transform: uppercase;
+}
+
 .pagination {
 	display: flex;
 	justify-content: flex-end;

--- a/plugins/appstip-appointments/assets/backend/admin/pages/Calendar/Calendar.tsx
+++ b/plugins/appstip-appointments/assets/backend/admin/pages/Calendar/Calendar.tsx
@@ -98,6 +98,21 @@ function getCalendarMonth(
 	return days;
 }
 
+function isMultiDay(appointment: Appointment) {
+	if (!appointment.endTimestamp) {
+		return false;
+	}
+
+	const start = new Date(appointment.timestamp * 1000);
+	const end = new Date(appointment.endTimestamp * 1000);
+
+	return (
+		start.getFullYear() !== end.getFullYear() ||
+		start.getMonth() !== end.getMonth() ||
+		start.getDate() !== end.getDate()
+	);
+}
+
 function applyAppointmentsToCalendar(
 	calendar: ReturnType<typeof getCalendarMonth>,
 	appointments: Appointment[]
@@ -329,6 +344,30 @@ export default function Calendar() {
 												}}
 											>
 												{appointment.service}
+												{appointment.allDay && (
+													<span
+														className={
+															styles.eventBadge
+														}
+													>
+														{__(
+															'All day',
+															'appstip-appointments'
+														)}
+													</span>
+												)}
+												{isMultiDay(appointment) && (
+													<span
+														className={
+															styles.eventBadge
+														}
+													>
+														{__(
+															'Multi-day',
+															'appstip-appointments'
+														)}
+													</span>
+												)}
 												<span className="screen-reader-text">
 													{` (${appointment.status})`}
 												</span>

--- a/plugins/appstip-appointments/assets/backend/schemas.ts
+++ b/plugins/appstip-appointments/assets/backend/schemas.ts
@@ -38,4 +38,6 @@ export const AppointmentSchema = object({
 	]),
 	customer: CustomerSchema,
 	customerId: optional(number()),
+	endTimestamp: optional(number()),
+	allDay: optional(boolean()),
 });

--- a/plugins/appstip-appointments/src/Data/Query/AppointmentsQuery.php
+++ b/plugins/appstip-appointments/src/Data/Query/AppointmentsQuery.php
@@ -92,11 +92,13 @@ class AppointmentsQuery {
 			$appointments[] = self::normalize(
 				$post->ID,
 				array(
-					'status'      => get_post_meta( $post->ID, 'status', true ),
-					'timestamp'   => get_post_meta( $post->ID, 'timestamp', true ),
-					'customer_id' => get_post_meta( $post->ID, 'customer_id', true ),
-					'customer'    => get_post_meta( $post->ID, 'customer', true ),
-					'duration'    => get_post_meta( $post->ID, 'duration', true ),
+					'status'        => get_post_meta( $post->ID, 'status', true ),
+					'timestamp'     => get_post_meta( $post->ID, 'timestamp', true ),
+					'customer_id'   => get_post_meta( $post->ID, 'customer_id', true ),
+					'customer'      => get_post_meta( $post->ID, 'customer', true ),
+					'duration'      => get_post_meta( $post->ID, 'duration', true ),
+					'end_timestamp' => get_post_meta( $post->ID, 'end_timestamp', true ),
+					'all_day'       => get_post_meta( $post->ID, 'all_day', true ),
 				)
 			);
 		}
@@ -160,11 +162,13 @@ class AppointmentsQuery {
 			$appointments[] = self::normalize(
 				$post->ID,
 				array(
-					'status'      => $meta['status'][0],
-					'timestamp'   => $meta['timestamp'][0],
-					'customer_id' => $meta['customer_id'][0],
-					'customer'    => $meta['customer'][0],
-					'duration'    => $meta['duration'][0],
+					'status'        => $meta['status'][0],
+					'timestamp'     => $meta['timestamp'][0],
+					'customer_id'   => $meta['customer_id'][0],
+					'customer'      => $meta['customer'][0],
+					'duration'      => $meta['duration'][0],
+					'end_timestamp' => $meta['end_timestamp'][0] ?? '',
+					'all_day'       => $meta['all_day'][0] ?? '',
 				)
 			);
 		}

--- a/plugins/appstip-appointments/tests/php/Data/Query/AppointmentsQueryTest.php
+++ b/plugins/appstip-appointments/tests/php/Data/Query/AppointmentsQueryTest.php
@@ -62,6 +62,58 @@ test(
 );
 
 test(
+	'AppointmentsQuery::all surfaces all_day and end_timestamp meta',
+	function () {
+		$start = time() + 3600;
+		$end   = $start + 2 * DAY_IN_SECONDS;
+
+		$this->create_appointment(
+			array(
+				'meta' => array(
+					'timestamp'     => $start,
+					'duration'      => 60,
+					'status'        => 'confirmed',
+					'end_timestamp' => $end,
+					'all_day'       => 1,
+				),
+			)
+		);
+
+		$results = AppointmentsQuery::all( array() );
+
+		expect( $results['appointments'] )->toHaveCount( 1 );
+		expect( $results['appointments'][0]['endTimestamp'] )->toBe( $end );
+		expect( $results['appointments'][0]['allDay'] )->toBeTrue();
+	}
+);
+
+test(
+	'AppointmentsQuery::upcoming surfaces all_day and end_timestamp meta',
+	function () {
+		$start = time() + 3600;
+		$end   = $start + 2 * DAY_IN_SECONDS;
+
+		$this->create_appointment(
+			array(
+				'meta' => array(
+					'timestamp'     => $start,
+					'duration'      => 60,
+					'status'        => 'confirmed',
+					'end_timestamp' => $end,
+					'all_day'       => 1,
+				),
+			)
+		);
+
+		$results = AppointmentsQuery::upcoming( array() );
+
+		expect( $results['appointments'] )->toHaveCount( 1 );
+		expect( $results['appointments'][0]['endTimestamp'] )->toBe( $end );
+		expect( $results['appointments'][0]['allDay'] )->toBeTrue();
+	}
+);
+
+test(
 	'AppointmentsQuery::get_date_range_appointments filters by entity_id',
 	function () {
 		$now   = time();


### PR DESCRIPTION
## What

Admin UI to create/edit **multi-day** and **all-day** appointments. The CORE-A1 backend (#460) already accepts and validates `endDate` + `allDay`; this PR wires the admin appointment form to actually send them. No PHP changes.

Stacked on #460 (`feat/appointment-model-seams`) — review/merge that first.

## Changes (frontend only)
- **Schema** (`schemas.ts`): added `endTimestamp` + `allDay` (optional) to `AppointmentSchema`; the `Appointment` type derives them.
- **AppointmentForm**:
  - "All day" `ToggleControl` — hides the time-of-day picker and swaps in a start-day date picker (an all-day appointment has no clock time).
  - Optional "End date" picker for multi-day spans, with in-calendar blocking of dates before the start and a clear button.
  - `onSubmit`: always sends `allDay`; sends `endDate` only when it resolves strictly after the start (the backend rule for setting `end_timestamp`); time fields aren't required when all-day. All-day end = end-of-day of the final day; non-all-day multi-day end mirrors the start time.
  - Edit mode seeds `allDay` + `endDate` from the appointment's `allDay`/`endTimestamp`.

## Backward compatibility
Strictly additive. With all-day off and no end date, the submitted payload is unchanged (an `undefined` end date is dropped by JSON serialization).

## Verification
- `wp-scripts lint-js` clean, `tsc --noEmit` clean, admin build succeeds.
- **In-browser (wp-env)**: created an all-day appointment June 11→13. Persisted meta confirmed: `all_day=1`, `timestamp` = June 11 00:00 local, `end_timestamp` = June 13 23:59:59 local. POST returned 200, list refetched.

## Follow-up polish (added in this PR)
- End-date picker is now collapsed by default behind an "Add end date" button (the always-open inline calendar made the form tall); opens automatically when editing an appointment that already has an end date.
- Calendar and appointments table show "All day" / "Multi-day" badges.
- Fixed a CORE-A1 data-layer gap surfaced by the badges: `AppointmentsQuery::all` / `::upcoming` were not forwarding `end_timestamp`/`all_day` to `normalize()`, so the admin list/calendar reported `allDay=false` and a duration-derived end. Both now forward those keys (mirroring `get_date_range_appointments`); added Pest coverage. Full suite green (286).
- Verified in-browser: all-day June 11-13 appointment shows both badges in calendar + table; end-date toggle collapses correctly.
